### PR TITLE
Create project homepage and move blog to archive

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,10 @@
 #
 
 # Name of your site (displayed in the header)
-name: Jarb (Just another R blog)
+name: pelld projects
 
 # Short bio or description (displayed in the header)
-description: David in Cambridge
+description: Games, tools and experiments
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,19 +24,15 @@
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
-          
           <div class="site-info">
             <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
             <p class="site-description">{{ site.description }}</p>
           </div>
           
           <nav>
-            <a href="{{ site.baseurl }}/">Blog</a>
-            <a href="{{ site.baseurl }}/about">About</a>
-            <a href="{{ site.baseurl }}/indexbrief">Index</a>
-            <!--<a href="{{ site.baseurl }}/tags">Tags</a>-->
-            <a href="{{ site.baseurl }}/links">Links</a>
+            <a href="{{ site.baseurl }}/">Projects</a>
+            <a href="{{ site.baseurl }}/blog/">Old blog</a>
+            <a href="https://github.com/pelld">GitHub</a>
           </nav>
         </header>
       </div>
@@ -49,7 +45,7 @@
     <div class="wrapper-footer">
       <div class="container">
         <footer class="footer">
-          {% include svg-icons.html %}
+          <p>Built by pelld · <a href="https://github.com/pelld">View code on GitHub</a></p>
         </footer>
       </div>
     </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Jarb archive
+permalink: /blog/
+---
+
+<p class="archive-intro">Short coding notes from 2016. These posts have been kept as an archive, with their original web addresses unchanged.</p>
+
+<div class="posts">
+  {% for post in site.posts %}
+    <article class="post archive-post">
+      <p class="archive-date">{{ post.date | date: "%d %B %Y" }}</p>
+      <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
+      <div class="entry">{{ post.excerpt }}</div>
+      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read post →</a>
+    </article>
+  {% endfor %}
+</div>

--- a/index.html
+++ b/index.html
@@ -1,18 +1,43 @@
 ---
 layout: default
+title: Projects
 ---
 
-<div class="posts">
-  {% for post in site.posts %}
-    <article class="post">
+<section class="project-hero">
+  <p class="eyebrow">pelld projects</p>
+  <h1>Games, tools and experiments.</h1>
+  <p>A growing collection of things made for the web — some useful, some playful, and some still being worked out.</p>
+</section>
 
-      <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+<section class="project-section">
+  <div class="section-heading">
+    <div><p class="eyebrow">Explore</p><h2>Tools and experiments</h2></div>
+  </div>
+  <div class="project-grid project-grid-featured">
+    <a class="project-card card-art" href="https://pelld.github.io/where-is-the-art/">
+      <span class="project-label">Art explorer</span>
+      <h3>Where Is the Art?</h3>
+      <p>Discover which museums hold works by an artist, or see what art is nearby when planning a trip.</p>
+      <span class="project-link">Explore the map <span aria-hidden="true">→</span></span>
+    </a>
+  </div>
+</section>
 
-      <div class="entry">
-        {{ post.excerpt }}
-      </div>
+<section class="project-section">
+  <div class="section-heading">
+    <div><p class="eyebrow">Burtree Gaming Studios</p><h2>Games</h2></div>
+    <p>Small, phone-friendly games made for family and friends.</p>
+  </div>
+  <div class="project-grid">
+    <a class="project-card card-quiz" href="https://pelld.github.io/quiz-duel-stars/"><span class="project-label">Quiz</span><h3>Quiz Duel Stars</h3><p>A head-to-head trivia game for playing together across two devices.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
+    <a class="project-card card-nepal" href="https://pelld.github.io/amelia-nepal-game/"><span class="project-label">Adventure</span><h3>Amelia in Nepal</h3><p>A mountain adventure through Nepal, built as a personalised game.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
+    <a class="project-card card-bike" href="https://pelld.github.io/hunter-dirt-bike-adventure/"><span class="project-label">Action</span><h3>Hunter's Dirt Bike Adventure</h3><p>Ride, jump and perform tricks across a North Pennines landscape.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
+    <a class="project-card card-dash" href="https://pelld.github.io/dirt-bike-dash/"><span class="project-label">Two player</span><h3>Dirt Bike Dash</h3><p>A quick dirt-bike challenge designed for two players.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
+    <a class="project-card card-animal" href="https://pelld.github.io/animal-dash/"><span class="project-label">Arcade</span><h3>Animal Dash</h3><p>A bright, simple action game suitable for younger players.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
+  </div>
+</section>
 
-      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-    </article>
-  {% endfor %}
-</div>
+<section class="archive-strip">
+  <div><p class="eyebrow">From the archive</p><h2>Jarb: Just another R blog</h2><p>Short notes about R, SQL, SAS and assorted coding problems, written in 2016.</p></div>
+  <a class="archive-button" href="{{ site.baseurl }}/blog/">Browse the old blog <span aria-hidden="true">→</span></a>
+</section>

--- a/style.scss
+++ b/style.scss
@@ -9,6 +9,54 @@
 @import "variables";
 // Syntax highlighting @import is at the bottom of this file
 
+// ============================================================
+// 00. PROJECT HOMEPAGE
+// ============================================================
+
+.project-hero { padding: 52px 0 68px; max-width: 680px; }
+.project-hero h1 { margin: 4px 0 18px; font-size: clamp(42px, 7vw, 72px); line-height: 1.02; letter-spacing: -3px; }
+.project-hero > p:last-child { max-width: 600px; color: #5e6472; font-size: 21px; line-height: 1.55; }
+.eyebrow { margin: 0; color: #6254a8; font-size: 13px; font-weight: 700; letter-spacing: 1.6px; text-transform: uppercase; }
+.project-section { margin: 0 0 72px; }
+.section-heading { display: flex; align-items: end; justify-content: space-between; gap: 30px; margin-bottom: 24px; }
+.section-heading h2, .archive-strip h2 { margin: 3px 0 0; font-size: 30px; }
+.section-heading > p { max-width: 310px; margin: 0; color: #707582; font-size: 15px; text-align: right; }
+.project-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.project-grid-featured { grid-template-columns: 1fr; }
+.project-card { position: relative; display: flex; min-height: 250px; padding: 28px; overflow: hidden; flex-direction: column; color: #1e2230; background: #f5f2eb; border: 1px solid #e5e0d6; border-radius: 18px; transition: transform .18s ease, box-shadow .18s ease; }
+.project-card:hover { color: #1e2230; transform: translateY(-4px); box-shadow: 0 14px 34px rgba(30,34,48,.12); }
+.project-card h3 { max-width: 390px; margin: 24px 0 8px; font-size: 27px; line-height: 1.15; }
+.project-card p { max-width: 490px; margin: 0 0 24px; color: #555c69; font-size: 16px; }
+.project-label { align-self: flex-start; padding: 6px 10px; color: #4d456f; background: rgba(255,255,255,.72); border-radius: 999px; font-size: 12px; font-weight: 700; letter-spacing: .7px; text-transform: uppercase; }
+.project-link { margin-top: auto; font-weight: 700; }
+.card-art { min-height: 310px; color: #172a28; background: linear-gradient(125deg,#d9eee9 0%,#edf5e2 54%,#f8e8cf 100%); border-color: #c9dfd9; }
+.card-art:hover { color: #172a28; }
+.card-art h3 { margin-top: 48px; font-size: 38px; }
+.card-quiz { background: #f0eafd; border-color: #ddd2f4; }
+.card-nepal { background: #e5f1ec; border-color: #cfe2da; }
+.card-bike { background: #f7e7d3; border-color: #ead1b5; }
+.card-dash { background: #e9eef9; border-color: #d3dced; }
+.card-animal { background: #faecd9; border-color: #efd8b8; }
+.archive-strip { display: flex; align-items: center; justify-content: space-between; gap: 32px; margin: 0 0 52px; padding: 34px; background: #252936; border-radius: 18px; }
+.archive-strip h2, .archive-strip p { color: #fff; }
+.archive-strip > div > p:last-child { max-width: 480px; color: #c7cad2; font-size: 15px; }
+.archive-strip .eyebrow { color: #b9aceb; }
+.archive-button { flex: 0 0 auto; padding: 13px 17px; color: #252936; background: #fff; border-radius: 10px; font-weight: 700; }
+.archive-button:hover { color: #252936; background: #f0edf9; }
+.archive-intro { margin-bottom: 42px; color: #656b78; font-size: 19px; }
+.archive-post h2 { margin: 2px 0 8px; }
+.archive-date { margin: 0; color: #787e89; font-size: 13px; text-transform: uppercase; letter-spacing: .7px; }
+
+@media screen and (max-width: 640px) {
+  .project-hero { padding: 30px 0 48px; }
+  .project-hero h1 { font-size: 45px; letter-spacing: -2px; }
+  .section-heading, .archive-strip { align-items: flex-start; flex-direction: column; }
+  .section-heading > p { text-align: left; }
+  .project-grid { grid-template-columns: 1fr; }
+  .project-card, .card-art { min-height: 250px; }
+  .card-art h3 { margin-top: 30px; font-size: 32px; }
+}
+
 /**************/
 /* BASE RULES */
 /**************/


### PR DESCRIPTION
## What changed

- replaces the old blog index at the root with a project-led **pelld projects** homepage
- lists the six public, accessible projects and intentionally excludes the login-protected Our Days app
- groups the games under Burtree Gaming Studios
- adds the old Jarb blog index at `/blog/`
- preserves the original article URLs
- refreshes the site header, footer and responsive card styling

## Why

The root GitHub Pages address should work as an understated index of public projects rather than opening directly into the old 2016 blog.

## Validation

- confirmed all six linked project URLs currently return successfully
- checked the changes for whitespace errors
- local Jekyll rendering was unavailable because the workspace does not include Ruby; GitHub Pages should perform the authoritative build check on this draft