### PR TITLE
Build standalone project showcase homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }} · {{ site.name }}</title>
+    <meta name="description" content="{{ site.description }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Manrope:wght@500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ site.baseurl }}/home.css">
+  </head>
+  <body>
+    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#games">Games</a><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
+    {{ content }}
+    <footer class="home-footer"><div class="shell"><a class="wordmark footer-mark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><p>Games, tools and experiments.</p><a href="https://github.com/pelld">View code on GitHub ↗</a></div></footer>
+  </body>
+</html>

--- a/home.css
+++ b/home.css
@@ -1,0 +1,65 @@
+:root { --ink:#171820; --muted:#626573; --paper:#f6f4ef; --purple:#7657db; --lime:#c8f169; --orange:#ff855d; --line:#dedbd2; }
+* { box-sizing:border-box; }
+html { scroll-behavior:smooth; }
+body { margin:0; color:var(--ink); background:var(--paper); font-family:"DM Sans",sans-serif; -webkit-font-smoothing:antialiased; }
+a { color:inherit; text-decoration:none; }
+.shell { width:min(1180px,calc(100% - 48px)); margin-inline:auto; }
+.home-header { display:flex; align-items:center; justify-content:space-between; height:92px; }
+.wordmark { display:flex; align-items:center; gap:10px; font-family:"Manrope",sans-serif; font-size:17px; font-weight:800; letter-spacing:-.3px; }
+.wordmark span { display:grid; width:34px; height:34px; color:white; background:var(--ink); border-radius:10px; place-items:center; font-size:20px; }
+.home-header nav { display:flex; align-items:center; gap:30px; font-size:14px; font-weight:600; }
+.home-header nav a { transition:opacity .2s; }
+.home-header nav a:hover { opacity:.58; }
+.nav-github { padding:10px 15px; border:1px solid #c9c6bd; border-radius:999px; }
+.hero { display:grid; min-height:610px; grid-template-columns:1.08fr .92fr; align-items:center; gap:55px; padding-block:55px 95px; }
+.kicker { margin:0 0 15px; color:#6551b5; font-size:12px; font-weight:800; letter-spacing:1.7px; text-transform:uppercase; }
+.hero h1 { margin:0; font-family:"Manrope",sans-serif; font-size:clamp(58px,7.5vw,100px); line-height:.94; letter-spacing:-6px; }
+.hero h1 span { color:var(--purple); }
+.hero-intro { max-width:610px; margin:30px 0 0; color:var(--muted); font-size:20px; line-height:1.6; }
+.hero-actions { display:flex; align-items:center; gap:28px; margin-top:38px; }
+.button { display:inline-flex; align-items:center; justify-content:center; padding:15px 21px; border-radius:12px; font-weight:700; }
+.button-dark { color:white; background:var(--ink); }
+.text-link { font-weight:700; }
+.text-link span { margin-left:5px; }
+.hero-graphic { position:relative; min-height:480px; overflow:hidden; background:#ded6fa; border-radius:34px; isolation:isolate; }
+.hero-graphic:before { position:absolute; width:320px; height:320px; content:""; right:-60px; bottom:-80px; background:var(--lime); border-radius:50%; }
+.orbit { position:absolute; width:340px; height:340px; border:1px solid rgba(34,28,52,.2); border-radius:50%; }
+.orbit-one { top:54px; left:55px; }.orbit-two { top:100px; left:100px; }
+.shape { position:absolute; display:grid; width:92px; height:92px; border-radius:28px; place-items:center; font-family:"Manrope"; font-size:44px; font-weight:800; box-shadow:0 18px 35px rgba(41,31,72,.16); transform:rotate(-7deg); }
+.shape-purple { top:105px; left:82px; color:white; background:var(--purple); }.shape-green { top:205px; right:85px; background:var(--lime); transform:rotate(9deg); }.shape-orange { right:170px; bottom:70px; color:white; background:var(--orange); transform:rotate(-12deg); }
+.graphic-card { position:absolute; left:38px; bottom:36px; display:flex; padding:16px 20px; flex-direction:column; background:rgba(255,255,255,.88); border:1px solid rgba(255,255,255,.7); border-radius:15px; backdrop-filter:blur(12px); }
+.graphic-card span { color:var(--muted); font-size:11px; letter-spacing:1px; text-transform:uppercase; }.graphic-card strong { margin-top:4px; font-family:"Manrope"; }
+.work { padding-block:90px 120px; }
+.section-title { display:flex; align-items:end; justify-content:space-between; gap:50px; margin-bottom:38px; }
+.section-title h2 { margin:0; font-family:"Manrope"; font-size:clamp(38px,5vw,64px); line-height:1; letter-spacing:-3px; }
+.section-title > p { max-width:405px; margin:0; color:var(--muted); font-size:17px; line-height:1.55; }
+.feature-card { display:grid; min-height:510px; overflow:hidden; grid-template-columns:.8fr 1.2fr; color:white; background:#202329; border-radius:28px; transition:transform .25s,box-shadow .25s; }
+.feature-card:hover { transform:translateY(-5px); box-shadow:0 22px 55px rgba(25,26,32,.2); }
+.feature-copy { display:flex; padding:55px; flex-direction:column; align-items:flex-start; }
+.pill { padding:8px 12px; color:#d8d3eb; border:1px solid #565963; border-radius:999px; font-size:11px; font-weight:700; letter-spacing:1px; text-transform:uppercase; }
+.feature-copy h3 { margin:60px 0 16px; font-family:"Manrope"; font-size:52px; line-height:1; letter-spacing:-2.5px; }
+.feature-copy p { margin:0; color:#c3c5ca; font-size:18px; line-height:1.55; }
+.open-link { margin-top:auto; font-weight:700; }.open-link b { display:inline-grid; width:28px; height:28px; margin-left:8px; color:#202329; background:var(--lime); border-radius:50%; place-items:center; }
+.map-art { position:relative; min-height:510px; overflow:hidden; background:#d9e8e1; }
+.map-art:before,.map-art:after { position:absolute; content:""; background:#f3eee2; border:2px solid #c7d3cb; border-radius:48% 52% 55% 45%; transform:rotate(18deg); }
+.map-art:before { width:360px; height:270px; top:38px; left:70px; }.map-art:after { width:260px; height:210px; right:-50px; bottom:30px; }
+.land { position:absolute; background:#e8cfae; opacity:.72; border-radius:50%; }.land-one { width:150px;height:90px;left:25px;bottom:30px;transform:rotate(-18deg); }.land-two { width:120px;height:180px;right:120px;top:-50px;transform:rotate(25deg); }
+.pin { position:absolute; z-index:2; width:22px; height:22px; background:var(--purple); border:5px solid white; border-radius:50% 50% 50% 0; box-shadow:0 5px 12px rgba(39,32,59,.25); transform:rotate(-45deg); }.pin-one{left:33%;top:30%;}.pin-two{left:58%;top:49%;background:var(--orange);}.pin-three{right:18%;top:24%;background:#31836a;}
+.map-panel { position:absolute; z-index:3; left:35px; bottom:35px; display:flex; width:210px; padding:18px; flex-direction:column; background:rgba(255,255,255,.9); border-radius:15px; box-shadow:0 14px 30px rgba(38,56,49,.14); backdrop-filter:blur(10px); }.map-panel span,.map-panel small{color:#71766f;font-size:11px;}.map-panel strong{margin:3px 0 8px;font-family:"Manrope";font-size:20px;}
+.games-section { padding-block:110px 125px; color:white; background:#171820; }
+.section-title.light .kicker { color:var(--lime); }.section-title.light > p { color:#aaaeba; }
+.games-grid { display:grid; grid-template-columns:repeat(6,1fr); gap:18px; }
+.game-card { grid-column:span 2; overflow:hidden; color:var(--ink); background:white; border-radius:22px; transition:transform .2s; }.game-card:hover { transform:translateY(-5px); }.game-card:nth-child(4),.game-card:nth-child(5){grid-column:span 3;}
+.game-visual { position:relative; display:flex; height:220px; overflow:hidden; align-items:center; justify-content:center; }
+.game-copy { padding:26px 28px 30px; }.game-copy > span { color:#656875; font-size:11px; font-weight:700; letter-spacing:1px; text-transform:uppercase; }.game-copy h3 { margin:10px 0 8px; font-family:"Manrope"; font-size:25px; line-height:1.1; letter-spacing:-.8px; }.game-copy p { min-height:50px; margin:0 0 24px; color:#656875; font-size:14px; line-height:1.5; }.game-copy b { font-size:13px; }
+.game-quiz .game-visual{background:#ded4ff}.quiz-bubble{display:grid;width:96px;height:96px;background:var(--purple);color:white;border-radius:28px;place-items:center;font:800 58px "Manrope";transform:rotate(-8deg);box-shadow:0 14px 25px rgba(75,54,142,.25)}.quiz-bubble.second{width:62px;height:62px;margin:75px 0 0 -8px;color:var(--ink);background:var(--lime);font-size:34px;transform:rotate(12deg)}
+.game-nepal .game-visual{background:#cfe8dc}.mountain{position:absolute;width:0;height:0;border-left:130px solid transparent;border-right:130px solid transparent;border-bottom:180px solid #507b68;bottom:-30px}.mountain.back{left:-30px;border-left-width:100px;border-right-width:100px;border-bottom-color:#86ad9b;transform:scale(.8)}.mountain.front{right:-30px}.sun{position:absolute;width:60px;height:60px;top:35px;right:45px;background:#ffcf65;border-radius:50%}
+.game-bike .game-visual{background:#f4d5b4}.trail{position:absolute;width:130%;height:90px;bottom:-22px;background:#bc7345;transform:rotate(-9deg)}.wheel{position:absolute;width:52px;height:52px;bottom:53px;border:9px solid #303139;border-radius:50%}.wheel-one{left:31%}.wheel-two{right:29%}.rider{position:absolute;top:62px;font:800 60px "Manrope";transform:rotate(-14deg)}
+.game-dash .game-visual{background:#bdd9ff}.speed-lines{background:repeating-linear-gradient(-14deg,#b9d7ff 0,#b9d7ff 24px,#d8e7ff 25px,#d8e7ff 35px)}.speed-lines strong{padding:13px 18px;color:white;background:#3157a8;border-radius:12px;font:800 45px "Manrope";transform:rotate(-6deg)}
+.game-animal .game-visual{gap:15px;background:#ffdca8}.animal-faces span{display:grid;width:80px;height:80px;background:#fff4df;border:4px solid #2e3038;border-radius:50%;place-items:center;font-weight:800;transform:rotate(-7deg)}.animal-faces span:nth-child(2){margin-top:50px;background:#d7efc0;transform:rotate(8deg)}
+.archive { display:grid; grid-template-columns:170px 1fr auto; align-items:center; gap:45px; padding-block:115px; }
+.archive-number { color:#dedad0; font:800 76px "Manrope"; letter-spacing:-5px; transform:rotate(-90deg); }
+.archive-copy h2 { margin:0; font:800 clamp(34px,4vw,52px)/1.05 "Manrope"; letter-spacing:-2px; }.archive-copy > p:last-child { max-width:650px; color:var(--muted); font-size:16px; line-height:1.6; }.button-light { border:1px solid #bdbab1; }
+.home-footer { padding-block:42px; color:white; background:#101116; }.home-footer .shell { display:flex; align-items:center; justify-content:space-between; }.footer-mark span{color:var(--ink);background:var(--lime)}.home-footer p,.home-footer > div > a:last-child{color:#aeb1ba;font-size:13px;}
+@media(max-width:850px){.home-header nav a:not(.nav-github){display:none}.hero{grid-template-columns:1fr;padding-top:35px}.hero-graphic{min-height:390px}.feature-card{grid-template-columns:1fr}.feature-copy{min-height:430px}.games-grid{grid-template-columns:1fr 1fr}.game-card,.game-card:nth-child(4),.game-card:nth-child(5){grid-column:span 1}.archive{grid-template-columns:1fr}.archive-number{display:none}.home-footer .shell{gap:20px;flex-direction:column;align-items:flex-start}}
+@media(max-width:560px){.shell{width:min(100% - 30px,1180px)}.home-header{height:76px}.nav-github{padding:8px 11px}.hero{min-height:auto;gap:35px;padding-bottom:70px}.hero h1{font-size:52px;letter-spacing:-3.5px}.hero-intro{font-size:17px}.hero-actions{align-items:flex-start;flex-direction:column;gap:18px}.hero-graphic{min-height:330px;border-radius:24px}.shape{width:72px;height:72px;border-radius:21px;font-size:35px}.shape-purple{top:65px;left:40px}.shape-green{top:125px;right:42px}.shape-orange{right:105px;bottom:55px}.graphic-card{left:20px;bottom:20px}.work,.games-section,.archive{padding-block:75px}.section-title{align-items:flex-start;flex-direction:column;gap:18px}.section-title h2{font-size:42px;letter-spacing:-2px}.feature-copy{min-height:390px;padding:32px}.feature-copy h3{margin-top:50px;font-size:40px}.map-art{min-height:360px}.games-grid{grid-template-columns:1fr}.game-visual{height:190px}.game-copy p{min-height:0}.archive{gap:20px}}

--- a/index.html
+++ b/index.html
@@ -1,43 +1,43 @@
 ---
-layout: default
+layout: home
 title: Projects
 ---
 
-<section class="project-hero">
-  <p class="eyebrow">pelld projects</p>
-  <h1>Games, tools and experiments.</h1>
-  <p>A growing collection of things made for the web — some useful, some playful, and some still being worked out.</p>
-</section>
+<main>
+  <section class="hero shell">
+    <div class="hero-copy">
+      <p class="kicker">Independent web projects</p>
+      <h1>Useful things.<br><span>Playful things.</span></h1>
+      <p class="hero-intro">A collection of games, tools and experiments made to solve a problem, explore an idea or simply see if it can be done.</p>
+      <div class="hero-actions"><a class="button button-dark" href="#projects">Explore projects</a><a class="text-link" href="{{ site.baseurl }}/blog/">Visit the old R blog <span>→</span></a></div>
+    </div>
+    <div class="hero-graphic" aria-hidden="true">
+      <div class="orbit orbit-one"></div><div class="orbit orbit-two"></div>
+      <div class="shape shape-purple">?</div><div class="shape shape-green">↗</div><div class="shape shape-orange">✦</div>
+      <div class="graphic-card"><span>Currently exploring</span><strong>art · maps · games</strong></div>
+    </div>
+  </section>
 
-<section class="project-section">
-  <div class="section-heading">
-    <div><p class="eyebrow">Explore</p><h2>Tools and experiments</h2></div>
-  </div>
-  <div class="project-grid project-grid-featured">
-    <a class="project-card card-art" href="https://pelld.github.io/where-is-the-art/">
-      <span class="project-label">Art explorer</span>
-      <h3>Where Is the Art?</h3>
-      <p>Discover which museums hold works by an artist, or see what art is nearby when planning a trip.</p>
-      <span class="project-link">Explore the map <span aria-hidden="true">→</span></span>
+  <section class="work shell" id="projects">
+    <div class="section-title"><div><p class="kicker">Featured project</p><h2>Find art anywhere.</h2></div><p>Search by artist to discover where their work is held, or start with a place to see what is nearby.</p></div>
+    <a class="feature-card" href="https://pelld.github.io/where-is-the-art/">
+      <div class="feature-copy"><span class="pill">Interactive art explorer</span><h3>Where Is the Art?</h3><p>From Rembrandt to Michelangelo: explore artworks, museums and locations on one map.</p><span class="open-link">Open the project <b>↗</b></span></div>
+      <div class="map-art" aria-hidden="true"><div class="land land-one"></div><div class="land land-two"></div><i class="pin pin-one"></i><i class="pin pin-two"></i><i class="pin pin-three"></i><div class="map-panel"><span>Artist</span><strong>Rembrandt</strong><small>Works across Europe</small></div></div>
     </a>
-  </div>
-</section>
+  </section>
 
-<section class="project-section">
-  <div class="section-heading">
-    <div><p class="eyebrow">Burtree Gaming Studios</p><h2>Games</h2></div>
-    <p>Small, phone-friendly games made for family and friends.</p>
-  </div>
-  <div class="project-grid">
-    <a class="project-card card-quiz" href="https://pelld.github.io/quiz-duel-stars/"><span class="project-label">Quiz</span><h3>Quiz Duel Stars</h3><p>A head-to-head trivia game for playing together across two devices.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
-    <a class="project-card card-nepal" href="https://pelld.github.io/amelia-nepal-game/"><span class="project-label">Adventure</span><h3>Amelia in Nepal</h3><p>A mountain adventure through Nepal, built as a personalised game.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
-    <a class="project-card card-bike" href="https://pelld.github.io/hunter-dirt-bike-adventure/"><span class="project-label">Action</span><h3>Hunter's Dirt Bike Adventure</h3><p>Ride, jump and perform tricks across a North Pennines landscape.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
-    <a class="project-card card-dash" href="https://pelld.github.io/dirt-bike-dash/"><span class="project-label">Two player</span><h3>Dirt Bike Dash</h3><p>A quick dirt-bike challenge designed for two players.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
-    <a class="project-card card-animal" href="https://pelld.github.io/animal-dash/"><span class="project-label">Arcade</span><h3>Animal Dash</h3><p>A bright, simple action game suitable for younger players.</p><span class="project-link">Play <span aria-hidden="true">→</span></span></a>
-  </div>
-</section>
+  <section class="games-section" id="games">
+    <div class="shell">
+      <div class="section-title light"><div><p class="kicker">Burtree Gaming Studios</p><h2>Made to be played.</h2></div><p>Small, phone-friendly games built for family, friends and two-player challenges.</p></div>
+      <div class="games-grid">
+        <a class="game-card game-quiz" href="https://pelld.github.io/quiz-duel-stars/"><div class="game-visual"><span class="quiz-bubble">?</span><span class="quiz-bubble second">!</span></div><div class="game-copy"><span>Quiz · Two devices</span><h3>Quiz Duel Stars</h3><p>Fast head-to-head trivia, played together from different phones.</p><b>Play now ↗</b></div></a>
+        <a class="game-card game-nepal" href="https://pelld.github.io/amelia-nepal-game/"><div class="game-visual"><div class="mountain back"></div><div class="mountain front"></div><span class="sun"></span></div><div class="game-copy"><span>Personal adventure</span><h3>Amelia in Nepal</h3><p>A journey through the mountains, made as a personalised game.</p><b>Play now ↗</b></div></a>
+        <a class="game-card game-bike" href="https://pelld.github.io/hunter-dirt-bike-adventure/"><div class="game-visual"><div class="trail"></div><span class="wheel wheel-one"></span><span class="wheel wheel-two"></span><span class="rider">↗</span></div><div class="game-copy"><span>Action · Tricks</span><h3>Hunter's Dirt Bike Adventure</h3><p>Ride, jump and perform tricks across the North Pennines.</p><b>Play now ↗</b></div></a>
+        <a class="game-card game-dash" href="https://pelld.github.io/dirt-bike-dash/"><div class="game-visual speed-lines"><strong>GO!</strong></div><div class="game-copy"><span>Race · Two player</span><h3>Dirt Bike Dash</h3><p>A quick dirt-bike challenge made for racing a friend.</p><b>Play now ↗</b></div></a>
+        <a class="game-card game-animal" href="https://pelld.github.io/animal-dash/"><div class="game-visual animal-faces"><span>●ᴥ●</span><span>•ᴥ•</span><span>●ᴥ●</span></div><div class="game-copy"><span>Arcade · Younger players</span><h3>Animal Dash</h3><p>A bright and simple action game for quick bursts of play.</p><b>Play now ↗</b></div></a>
+      </div>
+    </div>
+  </section>
 
-<section class="archive-strip">
-  <div><p class="eyebrow">From the archive</p><h2>Jarb: Just another R blog</h2><p>Short notes about R, SQL, SAS and assorted coding problems, written in 2016.</p></div>
-  <a class="archive-button" href="{{ site.baseurl }}/blog/">Browse the old blog <span aria-hidden="true">→</span></a>
-</section>
+  <section class="archive shell" id="archive"><div class="archive-number">2016</div><div class="archive-copy"><p class="kicker">Still here, safely archived</p><h2>Jarb: Just another R blog</h2><p>The original collection of short notes on R, SQL, SAS and coding problems. The blog and all its original posts remain available.</p></div><a class="button button-light" href="{{ site.baseurl }}/blog/">Browse the archive →</a></section>
+</main>


### PR DESCRIPTION
## What changed

- gives the root homepage a completely separate, wide showcase layout
- adds a visual hero, featured art project, game gallery and blog archive section
- keeps `/blog/` and all existing posts on their original Jekyll blog layout
- adds responsive desktop and mobile styling

## Safety

The blog content and blog layouts are not changed. The previous homepage remains available in Git history for rollback.