### PR TITLE
Add new analytical sites and automatic directory

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/home.css">
   </head>
   <body>
-    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#games">Games</a><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
+    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#insights">Health &amp; evidence</a><a href="#games">Games</a><a href="#directory">All sites</a><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
     {{ content }}
     <footer class="home-footer"><div class="shell"><a class="wordmark footer-mark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><p>Games, tools and experiments.</p><a href="https://github.com/pelld">View code on GitHub ↗</a></div></footer>
   </body>

--- a/home.css
+++ b/home.css
@@ -46,6 +46,31 @@ a { color:inherit; text-decoration:none; }
 .land { position:absolute; background:#e8cfae; opacity:.72; border-radius:50%; }.land-one { width:150px;height:90px;left:25px;bottom:30px;transform:rotate(-18deg); }.land-two { width:120px;height:180px;right:120px;top:-50px;transform:rotate(25deg); }
 .pin { position:absolute; z-index:2; width:22px; height:22px; background:var(--purple); border:5px solid white; border-radius:50% 50% 50% 0; box-shadow:0 5px 12px rgba(39,32,59,.25); transform:rotate(-45deg); }.pin-one{left:33%;top:30%;}.pin-two{left:58%;top:49%;background:var(--orange);}.pin-three{right:18%;top:24%;background:#31836a;}
 .map-panel { position:absolute; z-index:3; left:35px; bottom:35px; display:flex; width:210px; padding:18px; flex-direction:column; background:rgba(255,255,255,.9); border-radius:15px; box-shadow:0 14px 30px rgba(38,56,49,.14); backdrop-filter:blur(10px); }.map-panel span,.map-panel small{color:#71766f;font-size:11px;}.map-panel strong{margin:3px 0 8px;font-family:"Manrope";font-size:20px;}
+
+/* ============================================================
+   02. HEALTH, EVIDENCE AND SYSTEMS
+   ============================================================ */
+.insights-section { padding-block:110px 125px; background:#eaeef0; }
+.insights-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:20px; }
+.insight-card { display:grid; min-height:360px; overflow:hidden; grid-template-columns:42% 58%; background:white; border:1px solid #d7dcde; border-radius:24px; transition:transform .22s,box-shadow .22s; }
+.insight-card:hover { transform:translateY(-5px); box-shadow:0 18px 42px rgba(25,35,41,.12); }
+.insight-visual { position:relative; min-height:360px; overflow:hidden; }
+.insight-copy { display:flex; padding:34px 32px; flex-direction:column; align-items:flex-start; }
+.project-status { color:#657077; font-size:10px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
+.insight-copy h3 { margin:18px 0 12px; font:800 27px/1.12 "Manrope"; letter-spacing:-1px; }
+.insight-copy p { margin:0 0 24px; color:#626b70; font-size:14px; line-height:1.55; }
+.insight-copy b { margin-top:auto; font-size:13px; }
+.system-visual { background:#d6eee8; }
+.system-node { position:absolute; z-index:2; width:54px; height:54px; background:#147965; border:8px solid rgba(255,255,255,.7); border-radius:50%; box-shadow:0 8px 20px rgba(19,91,77,.2); }.node-a{top:58px;left:48px}.node-b{top:146px;right:44px;background:#6851be}.node-c{bottom:48px;left:52px;background:#e27a52}.node-d{bottom:76px;right:68px;width:34px;height:34px;border-width:6px}
+.system-line { position:absolute; height:3px; background:#879c98; transform-origin:left center; }.line-a{width:145px;top:91px;left:88px;transform:rotate(31deg)}.line-b{width:128px;top:180px;left:82px;transform:rotate(-39deg)}.line-c{width:100px;bottom:88px;left:88px;transform:rotate(8deg)}
+.prize-visual { background:#193f3b; }.prize-visual strong{position:absolute;right:18px;bottom:23px;color:#d8ed86;font:800 24px "Manrope"}.body-head{position:absolute;width:50px;height:50px;top:48px;left:calc(50% - 25px);background:#d4e4dd;border-radius:50%}.body-core{position:absolute;width:106px;height:190px;top:106px;left:calc(50% - 53px);background:#b6d0c5;border-radius:48px 48px 32px 32px}.body-point{position:absolute;z-index:2;width:22px;height:22px;background:#d8ed86;border:5px solid #fff;border-radius:50%;box-shadow:0 5px 12px rgba(0,0,0,.18)}.point-a{top:122px;left:45%}.point-b{top:174px;right:31%;background:#ff9b77}.point-c{top:238px;left:34%;background:#70c2c6}
+.atlas-visual { background:#dde9f2; }.atlas-map{position:absolute;width:138px;height:245px;top:45px;left:calc(50% - 69px);background:#7da9c2;border-radius:54% 46% 60% 40%;transform:rotate(7deg);clip-path:polygon(45% 0,76% 8%,73% 28%,96% 43%,70% 56%,83% 77%,51% 100%,25% 79%,30% 59%,5% 44%,30% 26%)}.atlas-dot{position:absolute;z-index:2;width:19px;height:19px;background:#744fc4;border:4px solid white;border-radius:50%}.dot-a{top:92px;left:44%}.dot-b{top:164px;right:34%;background:#dd6b4b}.dot-c{bottom:73px;left:38%;background:#16775f}.atlas-visual span{position:absolute;left:18px;bottom:18px;padding:7px 10px;background:white;border-radius:8px;font-weight:800;font-size:11px}
+.pvalue-visual { display:flex; align-items:flex-end; justify-content:center; gap:8px; padding:48px 22px 62px; background:#eee8fa; }.pvalue-visual i{width:18px;height:var(--h);background:#8066cb;border-radius:5px 5px 0 0}.pvalue-visual i.threshold{background:#ea7654}.pvalue-visual span{position:absolute;right:14px;bottom:19px;padding:6px 9px;background:white;border-radius:7px;font:700 11px "Manrope"}
+.prototype-note { margin:25px 0 0; padding:18px 22px; color:#586267; background:rgba(255,255,255,.62); border:1px solid #d7dcde; border-radius:13px; font-size:13px; line-height:1.55; }
+
+/* ============================================================
+   03. GAMES
+   ============================================================ */
 .games-section { padding-block:110px 125px; color:white; background:#171820; }
 .section-title.light .kicker { color:var(--lime); }.section-title.light > p { color:#aaaeba; }
 .games-grid { display:grid; grid-template-columns:repeat(6,1fr); gap:18px; }
@@ -57,9 +82,27 @@ a { color:inherit; text-decoration:none; }
 .game-bike .game-visual{background:#f4d5b4}.trail{position:absolute;width:130%;height:90px;bottom:-22px;background:#bc7345;transform:rotate(-9deg)}.wheel{position:absolute;width:52px;height:52px;bottom:53px;border:9px solid #303139;border-radius:50%}.wheel-one{left:31%}.wheel-two{right:29%}.rider{position:absolute;top:62px;font:800 60px "Manrope";transform:rotate(-14deg)}
 .game-dash .game-visual{background:#bdd9ff}.speed-lines{background:repeating-linear-gradient(-14deg,#b9d7ff 0,#b9d7ff 24px,#d8e7ff 25px,#d8e7ff 35px)}.speed-lines strong{padding:13px 18px;color:white;background:#3157a8;border-radius:12px;font:800 45px "Manrope";transform:rotate(-6deg)}
 .game-animal .game-visual{gap:15px;background:#ffdca8}.animal-faces span{display:grid;width:80px;height:80px;background:#fff4df;border:4px solid #2e3038;border-radius:50%;place-items:center;font-weight:800;transform:rotate(-7deg)}.animal-faces span:nth-child(2){margin-top:50px;background:#d7efc0;transform:rotate(8deg)}
+
+/* ============================================================
+   04. AUTOMATIC DIRECTORY
+   ============================================================ */
+.directory { padding-block:110px 80px; }
+.directory-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:13px; }
+.directory-card { display:flex; min-height:148px; padding:22px; flex-direction:column; background:white; border:1px solid var(--line); border-radius:16px; transition:border-color .18s,transform .18s; }
+.directory-card:hover { border-color:#a9a2c7; transform:translateY(-3px); }
+.directory-card span { color:#7562bb; font-size:10px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
+.directory-card h3 { margin:9px 0 7px; font:800 18px/1.2 "Manrope"; letter-spacing:-.4px; }
+.directory-card p { margin:0; color:var(--muted); font-size:12px; line-height:1.45; }
+.directory-card b { margin-top:auto; padding-top:13px; font-size:12px; }
+.directory-loading,.directory-error { grid-column:1/-1; padding:24px; color:var(--muted); background:white; border:1px solid var(--line); border-radius:14px; }
+.directory-note { margin-top:18px; color:#777a84; font-size:12px; }
+
+/* ============================================================
+   05. BLOG ARCHIVE AND FOOTER
+   ============================================================ */
 .archive { display:grid; grid-template-columns:170px 1fr auto; align-items:center; gap:45px; padding-block:115px; }
 .archive-number { color:#dedad0; font:800 76px "Manrope"; letter-spacing:-5px; transform:rotate(-90deg); }
 .archive-copy h2 { margin:0; font:800 clamp(34px,4vw,52px)/1.05 "Manrope"; letter-spacing:-2px; }.archive-copy > p:last-child { max-width:650px; color:var(--muted); font-size:16px; line-height:1.6; }.button-light { border:1px solid #bdbab1; }
 .home-footer { padding-block:42px; color:white; background:#101116; }.home-footer .shell { display:flex; align-items:center; justify-content:space-between; }.footer-mark span{color:var(--ink);background:var(--lime)}.home-footer p,.home-footer > div > a:last-child{color:#aeb1ba;font-size:13px;}
-@media(max-width:850px){.home-header nav a:not(.nav-github){display:none}.hero{grid-template-columns:1fr;padding-top:35px}.hero-graphic{min-height:390px}.feature-card{grid-template-columns:1fr}.feature-copy{min-height:430px}.games-grid{grid-template-columns:1fr 1fr}.game-card,.game-card:nth-child(4),.game-card:nth-child(5){grid-column:span 1}.archive{grid-template-columns:1fr}.archive-number{display:none}.home-footer .shell{gap:20px;flex-direction:column;align-items:flex-start}}
-@media(max-width:560px){.shell{width:min(100% - 30px,1180px)}.home-header{height:76px}.nav-github{padding:8px 11px}.hero{min-height:auto;gap:35px;padding-bottom:70px}.hero h1{font-size:52px;letter-spacing:-3.5px}.hero-intro{font-size:17px}.hero-actions{align-items:flex-start;flex-direction:column;gap:18px}.hero-graphic{min-height:330px;border-radius:24px}.shape{width:72px;height:72px;border-radius:21px;font-size:35px}.shape-purple{top:65px;left:40px}.shape-green{top:125px;right:42px}.shape-orange{right:105px;bottom:55px}.graphic-card{left:20px;bottom:20px}.work,.games-section,.archive{padding-block:75px}.section-title{align-items:flex-start;flex-direction:column;gap:18px}.section-title h2{font-size:42px;letter-spacing:-2px}.feature-copy{min-height:390px;padding:32px}.feature-copy h3{margin-top:50px;font-size:40px}.map-art{min-height:360px}.games-grid{grid-template-columns:1fr}.game-visual{height:190px}.game-copy p{min-height:0}.archive{gap:20px}}
+@media(max-width:850px){.home-header nav a:not(.nav-github){display:none}.hero{grid-template-columns:1fr;padding-top:35px}.hero-graphic{min-height:390px}.feature-card{grid-template-columns:1fr}.feature-copy{min-height:430px}.insights-grid{grid-template-columns:1fr}.games-grid{grid-template-columns:1fr 1fr}.game-card,.game-card:nth-child(4),.game-card:nth-child(5){grid-column:span 1}.directory-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.archive{grid-template-columns:1fr}.archive-number{display:none}.home-footer .shell{gap:20px;flex-direction:column;align-items:flex-start}}
+@media(max-width:560px){.shell{width:min(100% - 30px,1180px)}.home-header{height:76px}.nav-github{padding:8px 11px}.hero{min-height:auto;gap:35px;padding-bottom:70px}.hero h1{font-size:52px;letter-spacing:-3.5px}.hero-intro{font-size:17px}.hero-actions{align-items:flex-start;flex-direction:column;gap:18px}.hero-graphic{min-height:330px;border-radius:24px}.shape{width:72px;height:72px;border-radius:21px;font-size:35px}.shape-purple{top:65px;left:40px}.shape-green{top:125px;right:42px}.shape-orange{right:105px;bottom:55px}.graphic-card{left:20px;bottom:20px}.work,.insights-section,.games-section,.directory,.archive{padding-block:75px}.section-title{align-items:flex-start;flex-direction:column;gap:18px}.section-title h2{font-size:42px;letter-spacing:-2px}.feature-copy{min-height:390px;padding:32px}.feature-copy h3{margin-top:50px;font-size:40px}.map-art{min-height:360px}.insight-card{grid-template-columns:1fr}.insight-visual{min-height:230px}.insight-copy{min-height:280px}.games-grid,.directory-grid{grid-template-columns:1fr}.game-visual{height:190px}.game-copy p{min-height:0}.archive{gap:20px}}

--- a/index.html
+++ b/index.html
@@ -26,6 +26,37 @@ title: Projects
     </a>
   </section>
 
+  <!-- ============================================================
+       02. HEALTH, EVIDENCE AND SYSTEMS
+       ============================================================ -->
+  <section class="insights-section" id="insights">
+    <div class="shell">
+      <div class="section-title"><div><p class="kicker">Health, evidence and systems</p><h2>Explore the difficult questions.</h2></div><p>Interactive prototypes for investigating population health, evidence and the consequences of decisions across complex systems.</p></div>
+      <div class="insights-grid">
+        <a class="insight-card insight-system" href="https://pelld.github.io/population-health-system-explorer/">
+          <div class="insight-visual system-visual" aria-hidden="true"><span class="system-node node-a"></span><span class="system-node node-b"></span><span class="system-node node-c"></span><span class="system-node node-d"></span><i class="system-line line-a"></i><i class="system-line line-b"></i><i class="system-line line-c"></i></div>
+          <div class="insight-copy"><span class="project-status">Interactive systems map · Prototype</span><h3>Population Health: The Whole System</h3><p>Follow the relationships between wider determinants, prevention, treatment, recovery and longer lives—and keep asking why.</p><b>Explore the system ↗</b></div>
+        </a>
+        <a class="insight-card insight-prize" href="https://pelld.github.io/population-health-size-of-prize/">
+          <div class="insight-visual prize-visual" aria-hidden="true"><span class="body-head"></span><span class="body-core"></span><i class="body-point point-a"></i><i class="body-point point-b"></i><i class="body-point point-c"></i><strong>£1 → ?</strong></div>
+          <div class="insight-copy"><span class="project-status">Decision support · Illustrative prototype</span><h3>Population Health: Size of the Prize</h3><p>Explore how interventions affect the whole person and compare health, financial and societal returns.</p><b>Explore the opportunity ↗</b></div>
+        </a>
+        <a class="insight-card insight-atlas" href="https://pelld.github.io/population-health-atlas/">
+          <div class="insight-visual atlas-visual" aria-hidden="true"><div class="atlas-map"></div><i class="atlas-dot dot-a"></i><i class="atlas-dot dot-b"></i><i class="atlas-dot dot-c"></i><span>QOF</span></div>
+          <div class="insight-copy"><span class="project-status">Geographic analysis · Demonstration data</span><h3>Population Health Atlas</h3><p>Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.</p><b>Open the atlas ↗</b></div>
+        </a>
+        <a class="insight-card insight-pvalue" href="https://pelld.github.io/p-value-explorer/">
+          <div class="insight-visual pvalue-visual" aria-hidden="true"><i style="--h:34%"></i><i style="--h:58%"></i><i style="--h:82%"></i><i style="--h:48%"></i><i class="threshold" style="--h:92%"></i><i style="--h:28%"></i><span>p = .05</span></div>
+          <div class="insight-copy"><span class="project-status">PubMed evidence explorer</span><h3>P-Value Explorer</h3><p>Search PubMed abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.</p><b>Explore the evidence ↗</b></div>
+        </a>
+      </div>
+      <p class="prototype-note"><strong>About the prototypes:</strong> several projects currently use illustrative or demonstration data to develop the design and analytical approach. Each site explains what its results can—and cannot—show.</p>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       03. BURTREE GAMING STUDIOS
+       ============================================================ -->
   <section class="games-section" id="games">
     <div class="shell">
       <div class="section-title light"><div><p class="kicker">Burtree Gaming Studios</p><h2>Made to be played.</h2></div><p>Small, phone-friendly games built for family, friends and two-player challenges.</p></div>
@@ -39,5 +70,19 @@ title: Projects
     </div>
   </section>
 
+  <!-- ============================================================
+       04. AUTOMATIC SITE DIRECTORY
+       ============================================================ -->
+  <section class="directory shell" id="directory">
+    <div class="section-title"><div><p class="kicker">All public sites</p><h2>The complete directory.</h2></div><p>This list is read from GitHub automatically, so newly published public Pages sites can appear without rebuilding the homepage.</p></div>
+    <div id="site-directory" class="directory-grid" aria-live="polite"><p class="directory-loading">Looking for published sites…</p></div>
+    <p class="directory-note">The curated projects above include fuller descriptions. Login-protected and explicitly hidden projects are excluded from this public directory.</p>
+  </section>
+
+  <!-- ============================================================
+       05. BLOG ARCHIVE
+       ============================================================ -->
   <section class="archive shell" id="archive"><div class="archive-number">2016</div><div class="archive-copy"><p class="kicker">Still here, safely archived</p><h2>Jarb: Just another R blog</h2><p>The original collection of short notes on R, SQL, SAS and coding problems. The blog and all its original posts remain available.</p></div><a class="button button-light" href="{{ site.baseurl }}/blog/">Browse the archive →</a></section>
 </main>
+
+<script src="{{ site.baseurl }}/site-directory.js" defer></script>

--- a/site-directory.js
+++ b/site-directory.js
@@ -1,0 +1,110 @@
+/* ============================================================
+   00. AUTOMATIC GITHUB PAGES DIRECTORY
+   Reads public repositories from GitHub and lists those with
+   GitHub Pages enabled. Curated showcase content remains in HTML.
+   ============================================================ */
+
+const DIRECTORY_CONFIG = {
+  githubUser: "pelld",
+  rootRepository: "pelld.github.io",
+  excludedRepositories: ["our-days"],
+  apiUrl: "https://api.github.com/users/pelld/repos?per_page=100&sort=updated",
+  fallbackRepositories: [
+    { name: "where-is-the-art", description: "Find artworks and museums by artist or location." },
+    { name: "population-health-system-explorer", description: "Explore relationships across the population health system." },
+    { name: "population-health-size-of-prize", description: "Explore the potential impact of population health interventions." },
+    { name: "population-health-atlas", description: "Explore geographic clustering in recorded condition prevalence." },
+    { name: "p-value-explorer", description: "Inspect p-values reported in PubMed abstracts." },
+    { name: "quiz-duel-stars", description: "A head-to-head quiz played across two devices." },
+    { name: "amelia-nepal-game", description: "A personalised mountain adventure." },
+    { name: "hunter-dirt-bike-adventure", description: "Ride and perform tricks across the North Pennines." },
+    { name: "dirt-bike-dash", description: "A quick two-player dirt-bike challenge." },
+    { name: "animal-dash", description: "A bright action game for younger players." }
+  ]
+};
+
+const DISPLAY_NAMES = {
+  "where-is-the-art": "Where Is the Art?",
+  "population-health-system-explorer": "Population Health: The Whole System",
+  "population-health-size-of-prize": "Population Health: Size of the Prize",
+  "population-health-atlas": "Population Health Atlas",
+  "p-value-explorer": "P-Value Explorer",
+  "quiz-duel-stars": "Quiz Duel Stars",
+  "amelia-nepal-game": "Amelia in Nepal",
+  "hunter-dirt-bike-adventure": "Hunter's Dirt Bike Adventure",
+  "dirt-bike-dash": "Dirt Bike Dash",
+  "animal-dash": "Animal Dash"
+};
+
+/* ============================================================
+   01. DISPLAY HELPERS
+   GitHub topics provide deliberate grouping. Repository names
+   are used only as a fallback when a topic has not been added.
+   ============================================================ */
+
+function titleFromRepository(name) {
+  return DISPLAY_NAMES[name] || name.split("-").map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
+}
+
+function categoryFromRepository(repository) {
+  const topics = repository.topics || [];
+  if (topics.includes("game") || /game|dash|quiz/.test(repository.name)) return "Game";
+  if (topics.includes("population-health") || repository.name.startsWith("population-health-")) return "Population health";
+  if (topics.includes("evidence") || /p-value|evidence/.test(repository.name)) return "Evidence";
+  if (topics.includes("tool")) return "Tool";
+  return "Web project";
+}
+
+function pagesUrl(repository) {
+  return repository.homepage && /^https:\/\/pelld\.github\.io\//.test(repository.homepage) ? repository.homepage : `https://${DIRECTORY_CONFIG.githubUser}.github.io/${repository.name}/`;
+}
+
+/* ============================================================
+   02. DIRECTORY RENDERING
+   Text is inserted with textContent so repository data cannot
+   inject HTML into the homepage.
+   ============================================================ */
+
+function renderDirectory(repositories) {
+  const container = document.getElementById("site-directory");
+  container.replaceChildren();
+
+  repositories.forEach(repository => {
+    const card = document.createElement("a");
+    const category = document.createElement("span");
+    const title = document.createElement("h3");
+    const description = document.createElement("p");
+    const link = document.createElement("b");
+
+    card.className = "directory-card";
+    card.href = pagesUrl(repository);
+    category.textContent = categoryFromRepository(repository);
+    title.textContent = titleFromRepository(repository.name);
+    description.textContent = repository.description || "A public GitHub Pages project.";
+    link.textContent = "Open site ↗";
+    card.append(category, title, description, link);
+    container.append(card);
+  });
+}
+
+/* ============================================================
+   03. GITHUB DISCOVERY WITH STATIC FALLBACK
+   The fallback ensures the directory remains useful if GitHub's
+   public API is temporarily unavailable or rate-limited.
+   ============================================================ */
+
+async function loadDirectory() {
+  try {
+    const response = await fetch(DIRECTORY_CONFIG.apiUrl, { headers: { Accept: "application/vnd.github+json" } });
+    if (!response.ok) throw new Error(`GitHub returned ${response.status}`);
+
+    const repositories = await response.json();
+    const visiblePages = repositories.filter(repository => repository.has_pages && !repository.archived && repository.name !== DIRECTORY_CONFIG.rootRepository && !DIRECTORY_CONFIG.excludedRepositories.includes(repository.name) && !(repository.topics || []).includes("hide-from-homepage"));
+    renderDirectory(visiblePages);
+  } catch (error) {
+    console.warn("Automatic GitHub Pages discovery failed; using the saved directory.", error);
+    renderDirectory(DIRECTORY_CONFIG.fallbackRepositories);
+  }
+}
+
+loadDirectory();


### PR DESCRIPTION
## What changed

- adds a curated **Health, evidence and systems** section for four new public sites
- labels demonstration and illustrative prototypes transparently
- adds an automatic directory of public GitHub Pages repositories
- uses GitHub topics for deliberate grouping, with repository-name fallbacks
- excludes `our-days` and any future repository tagged `hide-from-homepage`
- provides a static fallback if GitHub's public API is unavailable

## New curated sites

- Population Health Atlas
- P-Value Explorer
- Population Health: The Whole System
- Population Health: Size of the Prize

## Validation

- JavaScript syntax checked with Node
- HTML contains ten unique curated project links
- diff checked for whitespace errors