### PR TITLE
Add Health System Levers to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ title: Projects
     <div class="hero-graphic" aria-hidden="true">
       <div class="orbit orbit-one"></div><div class="orbit orbit-two"></div>
       <div class="shape shape-purple">?</div><div class="shape shape-green">↗</div><div class="shape shape-orange">✦</div>
-      <div class="graphic-card"><span>Currently exploring</span><strong>art · maps · games</strong></div>
+      <div class="graphic-card"><span>Currently exploring</span><strong>health · evidence · games</strong></div>
     </div>
   </section>
 
@@ -48,6 +48,10 @@ title: Projects
         <a class="insight-card insight-pvalue" href="https://pelld.github.io/p-value-explorer/">
           <div class="insight-visual pvalue-visual" aria-hidden="true"><i style="--h:34%"></i><i style="--h:58%"></i><i style="--h:82%"></i><i style="--h:48%"></i><i class="threshold" style="--h:92%"></i><i style="--h:28%"></i><span>p = .05</span></div>
           <div class="insight-copy"><span class="project-status">PubMed evidence explorer</span><h3>P-Value Explorer</h3><p>Search PubMed abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.</p><b>Explore the evidence ↗</b></div>
+        </a>
+        <a class="insight-card insight-system" style="grid-column:1/-1" href="https://pelld.github.io/patient-flow-explorer/">
+          <div class="insight-visual system-visual" aria-hidden="true"><span class="system-node node-a"></span><span class="system-node node-b"></span><span class="system-node node-c"></span><span class="system-node node-d"></span><i class="system-line line-a"></i><i class="system-line line-b"></i><i class="system-line line-c"></i></div>
+          <div class="insight-copy"><span class="project-status">Evidence map · Early prototype</span><h3>Health System Levers</h3><p>Explore plain-language evidence statements about changes to health services, their reported outcomes and the strength of the evidence.</p><b>Explore the evidence map ↗</b></div>
         </a>
       </div>
       <p class="prototype-note"><strong>About the prototypes:</strong> several projects currently use illustrative or demonstration data to develop the design and analytical approach. Each site explains what its results can—and cannot—show.</p>

--- a/site-directory.js
+++ b/site-directory.js
@@ -15,6 +15,7 @@ const DIRECTORY_CONFIG = {
     { name: "population-health-size-of-prize", description: "Explore the potential impact of population health interventions." },
     { name: "population-health-atlas", description: "Explore geographic clustering in recorded condition prevalence." },
     { name: "p-value-explorer", description: "Inspect p-values reported in PubMed abstracts." },
+    { name: "patient-flow-explorer", description: "Explore evidence about changes to health services and their reported outcomes." },
     { name: "quiz-duel-stars", description: "A head-to-head quiz played across two devices." },
     { name: "amelia-nepal-game", description: "A personalised mountain adventure." },
     { name: "hunter-dirt-bike-adventure", description: "Ride and perform tricks across the North Pennines." },
@@ -29,6 +30,7 @@ const DISPLAY_NAMES = {
   "population-health-size-of-prize": "Population Health: Size of the Prize",
   "population-health-atlas": "Population Health Atlas",
   "p-value-explorer": "P-Value Explorer",
+  "patient-flow-explorer": "Health System Levers",
   "quiz-duel-stars": "Quiz Duel Stars",
   "amelia-nepal-game": "Amelia in Nepal",
   "hunter-dirt-bike-adventure": "Hunter's Dirt Bike Adventure",
@@ -50,7 +52,7 @@ function categoryFromRepository(repository) {
   const topics = repository.topics || [];
   if (topics.includes("game") || /game|dash|quiz/.test(repository.name)) return "Game";
   if (topics.includes("population-health") || repository.name.startsWith("population-health-")) return "Population health";
-  if (topics.includes("evidence") || /p-value|evidence/.test(repository.name)) return "Evidence";
+  if (topics.includes("evidence") || /p-value|patient-flow|evidence/.test(repository.name)) return "Evidence";
   if (topics.includes("tool")) return "Tool";
   return "Web project";
 }


### PR DESCRIPTION
## What changed

- added **Health System Levers** as a full card in the health, evidence and systems section
- linked the card to the Patient Flow Explorer GitHub Pages site
- added the site to the automatic directory fallback and display-name mapping
- categorised the repository as an evidence project
- updated the homepage hero wording to reflect the newer health and evidence projects

## Why

The project was created after the last homepage refresh, so it was only discoverable through the live GitHub API directory rather than the curated showcase or its static fallback.

## Checks

- compared the branch against `master`
- confirmed only `index.html` and `site-directory.js` changed
- branch is two commits ahead and contains no unrelated changes