### PR TITLE
Create an interactive living project map

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,12 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#0d0e13">
     <title>{{ page.title }} · {{ site.name }}</title>
     <meta name="description" content="{{ site.description }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Manrope:wght@500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ site.baseurl }}/home.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/home-universe.css">
   </head>
   <body>
     <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#insights">Health &amp; evidence</a><a href="#games">Games</a><a href="#directory">All sites</a><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>

--- a/home-universe.css
+++ b/home-universe.css
@@ -1,0 +1,100 @@
+/* ============================================================
+   00. LIVING PROJECT MAP — SHARED VARIABLES
+   ============================================================ */
+.project-universe { --universe-paper:#f7f7f2; --universe-ink:#0d0e13; --universe-muted:rgba(245,246,242,.62); position:relative; min-height:calc(100vh - 92px); overflow:hidden; color:var(--universe-paper); background:#0d0e13; isolation:isolate; }
+.project-universe:after { position:absolute; z-index:1; inset:0; content:""; pointer-events:none; background:linear-gradient(90deg,rgba(13,14,19,.92) 0%,rgba(13,14,19,.78) 35%,rgba(13,14,19,.08) 67%,rgba(13,14,19,.28) 100%),linear-gradient(180deg,rgba(13,14,19,.05),rgba(13,14,19,.35)); }
+#universe-canvas { position:absolute; z-index:0; inset:0; width:100%; height:100%; touch-action:pan-y; }
+.universe-grid { position:absolute; z-index:0; inset:0; opacity:.12; background-image:linear-gradient(rgba(255,255,255,.08) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.08) 1px,transparent 1px); background-size:64px 64px; mask-image:linear-gradient(to right,transparent 0%,black 42%,black 100%); }
+.universe-glow { position:absolute; z-index:0; width:620px; height:620px; pointer-events:none; border-radius:50%; filter:blur(100px); opacity:.12; }
+.universe-glow-one { top:-260px; right:8%; background:#7657db; }
+.universe-glow-two { right:-260px; bottom:-330px; background:#55d4a9; }
+
+/* ============================================================
+   01. PRIMARY COPY AND LAYOUT
+   ============================================================ */
+.universe-shell { position:relative; z-index:2; display:grid; min-height:calc(100vh - 92px); grid-template-columns:minmax(0,1fr) minmax(340px,.66fr); align-items:center; gap:70px; padding-block:72px 92px; pointer-events:none; }
+.universe-copy { max-width:760px; align-self:center; pointer-events:none; }
+.universe-kicker { display:flex; align-items:center; gap:10px; margin:0 0 28px; color:rgba(255,255,255,.66); font-size:11px; font-weight:800; letter-spacing:1.6px; text-transform:uppercase; }
+.universe-kicker span { width:7px; height:7px; background:#c8f169; border-radius:50%; box-shadow:0 0 0 6px rgba(200,241,105,.09),0 0 22px rgba(200,241,105,.55); }
+.universe-copy h1 { max-width:800px; margin:0; font-family:"Manrope",sans-serif; font-size:clamp(64px,7.2vw,112px); line-height:.87; letter-spacing:-7px; text-wrap:balance; }
+.universe-copy h1 em { color:transparent; font-style:normal; -webkit-text-stroke:1.5px rgba(247,247,242,.82); text-stroke:1.5px rgba(247,247,242,.82); }
+.universe-intro { max-width:620px; margin:33px 0 0; color:var(--universe-muted); font-size:18px; line-height:1.65; }
+.universe-actions { display:flex; align-items:center; gap:28px; margin-top:35px; pointer-events:auto; }
+.universe-button { display:inline-flex; align-items:center; gap:24px; padding:16px 19px 16px 22px; color:#111218; background:#c8f169; border-radius:999px; font-size:13px; font-weight:800; transition:transform .2s,box-shadow .2s; }
+.universe-button:hover { transform:translateY(-2px); box-shadow:0 14px 35px rgba(200,241,105,.18); }
+.universe-button span { display:grid; width:27px; height:27px; color:white; background:#111218; border-radius:50%; place-items:center; }
+.universe-text-link { color:rgba(255,255,255,.78); font-size:13px; font-weight:700; }
+.universe-text-link span { margin-left:6px; }
+.universe-themes { display:flex; flex-wrap:wrap; gap:8px; margin-top:35px; }
+.universe-themes span { padding:7px 10px; color:rgba(255,255,255,.48); border:1px solid rgba(255,255,255,.13); border-radius:999px; font-size:10px; font-weight:700; letter-spacing:.8px; text-transform:uppercase; }
+
+/* ============================================================
+   02. SELECTED PROJECT PANEL
+   ============================================================ */
+.universe-panel { width:min(100%,390px); align-self:end; justify-self:end; padding:24px 25px 22px; pointer-events:auto; background:rgba(22,23,31,.72); border:1px solid rgba(255,255,255,.14); border-radius:20px; box-shadow:0 24px 70px rgba(0,0,0,.28); backdrop-filter:blur(18px); }
+.universe-panel-top { display:flex; align-items:center; justify-content:space-between; gap:18px; }
+.universe-panel-index { color:#c8f169; font:800 11px "Manrope",sans-serif; letter-spacing:1.2px; }
+.universe-panel-type { overflow:hidden; color:rgba(255,255,255,.48); font-size:9px; font-weight:800; letter-spacing:1px; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
+.universe-panel h2 { margin:26px 0 12px; font:800 27px/1.05 "Manrope",sans-serif; letter-spacing:-1.2px; }
+.universe-panel > p { min-height:66px; margin:0; color:rgba(255,255,255,.58); font-size:13px; line-height:1.55; }
+.universe-panel-actions { display:flex; align-items:center; justify-content:space-between; gap:18px; margin-top:21px; }
+#universe-panel-link { color:white; font-size:12px; font-weight:800; }
+#universe-panel-link span { display:inline-grid; width:24px; height:24px; margin-left:7px; color:#111218; background:#c8f169; border-radius:50%; place-items:center; }
+.universe-accessible-list { display:flex; align-items:center; gap:5px; }
+.universe-accessible-list button { position:relative; width:8px; height:8px; padding:0; overflow:hidden; color:transparent; background:rgba(255,255,255,.24); border:0; border-radius:50%; cursor:pointer; transition:width .18s,background .18s; }
+.universe-accessible-list button[aria-pressed="true"] { width:22px; background:#c8f169; border-radius:999px; }
+.universe-accessible-list button:focus-visible { outline:2px solid white; outline-offset:3px; }
+
+/* ============================================================
+   03. EDGE DETAILS
+   ============================================================ */
+.universe-instruction { position:absolute; z-index:3; left:max(24px,calc((100vw - 1180px)/2)); bottom:27px; display:flex; align-items:center; gap:13px; color:rgba(255,255,255,.38); pointer-events:none; }
+.universe-instruction p { margin:0; font-size:9px; line-height:1.5; letter-spacing:.6px; text-transform:uppercase; }
+.universe-instruction strong { color:rgba(255,255,255,.7); font-weight:800; }
+.universe-mouse { position:relative; width:22px; height:32px; border:1px solid rgba(255,255,255,.35); border-radius:12px; }
+.universe-mouse:after { position:absolute; width:2px; height:6px; top:6px; left:9px; content:""; background:#c8f169; border-radius:999px; animation:universe-wheel 1.8s ease-in-out infinite; }
+.universe-counter { position:absolute; z-index:3; right:max(24px,calc((100vw - 1180px)/2)); top:28px; display:flex; align-items:center; gap:10px; color:rgba(255,255,255,.38); font:700 9px "Manrope",sans-serif; letter-spacing:1px; }
+.universe-counter span:first-child { color:white; }
+.universe-counter i { display:block; width:50px; height:1px; background:rgba(255,255,255,.2); }
+@keyframes universe-wheel { 0%,100% { opacity:.2; transform:translateY(0); } 45% { opacity:1; } 75% { opacity:0; transform:translateY(10px); } }
+
+/* ============================================================
+   04. TABLET AND MOBILE
+   ============================================================ */
+@media(max-width:980px) {
+  .project-universe:after { background:linear-gradient(180deg,rgba(13,14,19,.96) 0%,rgba(13,14,19,.76) 43%,rgba(13,14,19,.08) 70%,rgba(13,14,19,.44) 100%); }
+  .universe-shell { min-height:900px; grid-template-columns:1fr; align-items:start; gap:40px; padding-top:70px; }
+  .universe-copy { max-width:760px; }
+  .universe-copy h1 { max-width:720px; }
+  .universe-panel { width:min(100%,430px); align-self:end; justify-self:end; }
+  .universe-instruction { display:none; }
+}
+
+@media(max-width:560px) {
+  .project-universe { min-height:910px; }
+  .universe-grid { background-size:42px 42px; }
+  .universe-shell { min-height:910px; gap:25px; padding-block:42px 34px; }
+  .universe-kicker { margin-bottom:22px; font-size:9px; letter-spacing:1.2px; }
+  .universe-copy h1 { font-size:52px; line-height:.92; letter-spacing:-3.8px; }
+  .universe-copy h1 em { -webkit-text-stroke-width:1px; }
+  .universe-intro { max-width:94%; margin-top:24px; font-size:15px; line-height:1.55; }
+  .universe-actions { align-items:flex-start; flex-direction:column; gap:17px; margin-top:27px; }
+  .universe-button { padding:13px 16px 13px 18px; }
+  .universe-themes { margin-top:24px; }
+  .universe-panel { width:100%; padding:20px; border-radius:17px; }
+  .universe-panel h2 { margin-top:20px; font-size:23px; }
+  .universe-panel > p { min-height:60px; }
+  .universe-panel-actions { gap:12px; }
+  .universe-accessible-list { gap:4px; }
+  .universe-accessible-list button { width:7px; height:7px; }
+  .universe-accessible-list button[aria-pressed="true"] { width:17px; }
+  .universe-counter { display:none; }
+}
+
+/* ============================================================
+   05. ACCESSIBILITY AND LOW-MOTION MODE
+   ============================================================ */
+@media(prefers-reduced-motion:reduce) {
+  .universe-mouse:after { animation:none; }
+  .universe-button,.universe-accessible-list button { transition:none; }
+}

--- a/home-universe.js
+++ b/home-universe.js
@@ -1,0 +1,246 @@
+/* ============================================================
+   00. PROJECT DATA
+   ============================================================ */
+const universeProjects = [
+  { title:"Population Health: The Whole System", short:"Whole system", type:"Interactive systems map", description:"Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.", url:"https://pelld.github.io/population-health-system-explorer/", colour:"#71e2bd", x:.67, y:.25, radius:38 },
+  { title:"Population Health: Size of the Prize", short:"Size of the prize", type:"Decision support prototype", description:"Explore how interventions affect the whole person and compare health, financial and societal returns.", url:"https://pelld.github.io/population-health-size-of-prize/", colour:"#d9f279", x:.84, y:.38, radius:31 },
+  { title:"Population Health Atlas", short:"Health atlas", type:"Geographic analysis", description:"Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.", url:"https://pelld.github.io/population-health-atlas/", colour:"#78b9ef", x:.73, y:.57, radius:34 },
+  { title:"P-Value Explorer", short:"P-value explorer", type:"PubMed evidence explorer", description:"Search abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.", url:"https://pelld.github.io/p-value-explorer/", colour:"#aa8df4", x:.91, y:.68, radius:29 },
+  { title:"Where Is the Art?", short:"Where is the art?", type:"Interactive art map", description:"Search by artist or place to discover where artworks are held and what can be seen nearby.", url:"https://pelld.github.io/where-is-the-art/", colour:"#ff9775", x:.56, y:.72, radius:40 },
+  { title:"Quiz Duel Stars", short:"Quiz duel", type:"Two-device game", description:"Fast head-to-head trivia played together from different phones and different locations.", url:"https://pelld.github.io/quiz-duel-stars/", colour:"#f3d864", x:.42, y:.48, radius:30 },
+  { title:"Amelia in Nepal", short:"Amelia in Nepal", type:"Personal adventure", description:"A personalised journey through the mountains, built as a playable web adventure.", url:"https://pelld.github.io/amelia-nepal-game/", colour:"#80d9c8", x:.47, y:.23, radius:27 },
+  { title:"Hunter's Dirt Bike Adventure", short:"Dirt bike adventure", type:"Action game", description:"Ride, jump and perform tricks across a game-world inspired by the North Pennines.", url:"https://pelld.github.io/hunter-dirt-bike-adventure/", colour:"#eeb06f", x:.30, y:.68, radius:31 },
+  { title:"Animal Dash", short:"Animal dash", type:"Arcade game", description:"A bright and simple action game designed for younger players and quick bursts of play.", url:"https://pelld.github.io/animal-dash/", colour:"#ef8db3", x:.24, y:.35, radius:26 }
+];
+
+const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,6],[4,7],[5,6],[5,7],[5,8],[6,8],[7,8]];
+
+/* ============================================================
+   01. INITIALISE THE CANVAS AND INTERFACE
+   ============================================================ */
+(() => {
+  const canvas = document.getElementById("universe-canvas");
+  const universe = document.querySelector(".project-universe");
+  if (!canvas || !universe) return;
+
+  const context = canvas.getContext("2d");
+  const panelIndex = document.getElementById("universe-panel-index");
+  const panelType = document.getElementById("universe-panel-type");
+  const panelTitle = document.getElementById("universe-panel-title");
+  const panelDescription = document.getElementById("universe-panel-description");
+  const panelLink = document.getElementById("universe-panel-link");
+  const activeNumber = document.getElementById("universe-active-number");
+  const accessibleButtons = [...document.querySelectorAll(".universe-accessible-list button")];
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  let width = 0;
+  let height = 0;
+  let pixelRatio = 1;
+  let selectedProject = 0;
+  let hoverProject = -1;
+  let pointer = { x:-1000, y:-1000, active:false };
+  let scrollProgress = 0;
+  let animationFrame = 0;
+  let startTime = performance.now();
+
+  const nodes = universeProjects.map((project, index) => ({ ...project, index, px:0, py:0, displayX:0, displayY:0, velocityX:0, velocityY:0 }));
+
+  /* ============================================================
+     02. RESIZE AND POSITION NODES
+     ============================================================ */
+  const resize = () => {
+    const bounds = universe.getBoundingClientRect();
+    width = Math.max(320, bounds.width);
+    height = Math.max(560, bounds.height);
+    pixelRatio = Math.min(window.devicePixelRatio || 1, 1.75);
+    canvas.width = Math.round(width * pixelRatio);
+    canvas.height = Math.round(height * pixelRatio);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+
+    nodes.forEach(node => {
+      const mobile = width < 720;
+      node.px = mobile ? width * (.12 + node.x * .76) : width * node.x;
+      node.py = mobile ? height * (.39 + node.y * .49) : height * node.y;
+      if (!node.displayX) { node.displayX = node.px; node.displayY = node.py; }
+    });
+  };
+
+  /* ============================================================
+     03. PROJECT SELECTION
+     ============================================================ */
+  const selectProject = (index, pin = false) => {
+    const project = universeProjects[index];
+    if (!project) return;
+    if (pin) selectedProject = index;
+    panelIndex.textContent = `${String(index + 1).padStart(2, "0")} / ${String(universeProjects.length).padStart(2, "0")}`;
+    panelType.textContent = project.type;
+    panelTitle.textContent = project.title;
+    panelDescription.textContent = project.description;
+    panelLink.href = project.url;
+    activeNumber.textContent = String(index + 1).padStart(2, "0");
+    accessibleButtons.forEach((button, buttonIndex) => button.setAttribute("aria-pressed", buttonIndex === index ? "true" : "false"));
+  };
+
+  accessibleButtons.forEach(button => button.addEventListener("click", () => selectProject(Number(button.dataset.project), true)));
+
+  /* ============================================================
+     04. POINTER, TOUCH AND SCROLL INPUT
+     ============================================================ */
+  const setPointer = event => {
+    const bounds = canvas.getBoundingClientRect();
+    pointer.x = event.clientX - bounds.left;
+    pointer.y = event.clientY - bounds.top;
+    pointer.active = true;
+  };
+
+  canvas.addEventListener("pointermove", setPointer);
+  canvas.addEventListener("pointerleave", () => { pointer.active = false; hoverProject = -1; selectProject(selectedProject); });
+  canvas.addEventListener("pointerdown", event => {
+    setPointer(event);
+    if (hoverProject >= 0) selectProject(hoverProject, true);
+  });
+
+  window.addEventListener("scroll", () => {
+    const bounds = universe.getBoundingClientRect();
+    scrollProgress = Math.max(0, Math.min(1, -bounds.top / Math.max(1, bounds.height)));
+  }, { passive:true });
+
+  window.addEventListener("resize", resize);
+
+  /* ============================================================
+     05. DRAW HELPERS
+     ============================================================ */
+  const hexToRgba = (hex, alpha) => {
+    const value = parseInt(hex.slice(1), 16);
+    return `rgba(${value >> 16}, ${(value >> 8) & 255}, ${value & 255}, ${alpha})`;
+  };
+
+  const roundedRect = (x, y, w, h, radius) => {
+    const r = Math.min(radius, w / 2, h / 2);
+    context.beginPath();
+    context.moveTo(x + r, y);
+    context.arcTo(x + w, y, x + w, y + h, r);
+    context.arcTo(x + w, y + h, x, y + h, r);
+    context.arcTo(x, y + h, x, y, r);
+    context.arcTo(x, y, x + w, y, r);
+    context.closePath();
+  };
+
+  /* ============================================================
+     06. ANIMATION LOOP
+     ============================================================ */
+  const draw = now => {
+    const elapsed = (now - startTime) / 1000;
+    context.clearRect(0, 0, width, height);
+
+    hoverProject = -1;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    nodes.forEach(node => {
+      const driftX = prefersReducedMotion ? 0 : Math.sin(elapsed * .48 + node.index * 1.9) * 8;
+      const driftY = prefersReducedMotion ? 0 : Math.cos(elapsed * .42 + node.index * 1.4) * 7;
+      let targetX = node.px + driftX - scrollProgress * (node.index % 2 ? 24 : -18);
+      let targetY = node.py + driftY - scrollProgress * (20 + node.index * 2);
+
+      if (pointer.active) {
+        const dx = targetX - pointer.x;
+        const dy = targetY - pointer.y;
+        const distance = Math.hypot(dx, dy);
+        if (distance < 190 && distance > 0) {
+          const force = (190 - distance) / 190;
+          targetX += (dx / distance) * force * 30;
+          targetY += (dy / distance) * force * 30;
+        }
+      }
+
+      node.displayX += (targetX - node.displayX) * (prefersReducedMotion ? 1 : .055);
+      node.displayY += (targetY - node.displayY) * (prefersReducedMotion ? 1 : .055);
+
+      if (pointer.active) {
+        const distance = Math.hypot(node.displayX - pointer.x, node.displayY - pointer.y);
+        if (distance < node.radius + 34 && distance < closestDistance) { closestDistance = distance; hoverProject = node.index; }
+      }
+    });
+
+    universe.style.cursor = hoverProject >= 0 ? "pointer" : "default";
+    if (hoverProject >= 0) selectProject(hoverProject);
+
+    /* Draw connections behind the nodes. */
+    universeConnections.forEach(([fromIndex, toIndex]) => {
+      const from = nodes[fromIndex];
+      const to = nodes[toIndex];
+      const highlighted = [fromIndex, toIndex].includes(hoverProject >= 0 ? hoverProject : selectedProject);
+      const gradient = context.createLinearGradient(from.displayX, from.displayY, to.displayX, to.displayY);
+      gradient.addColorStop(0, hexToRgba(from.colour, highlighted ? .62 : .19));
+      gradient.addColorStop(1, hexToRgba(to.colour, highlighted ? .62 : .19));
+      context.strokeStyle = gradient;
+      context.lineWidth = highlighted ? 1.7 : .8;
+      context.beginPath();
+      context.moveTo(from.displayX, from.displayY);
+      context.lineTo(to.displayX, to.displayY);
+      context.stroke();
+    });
+
+    /* Draw each node, its orbit and its label. */
+    nodes.forEach(node => {
+      const activeIndex = hoverProject >= 0 ? hoverProject : selectedProject;
+      const active = node.index === activeIndex;
+      const radius = node.radius * (active ? 1.18 : 1);
+
+      context.strokeStyle = hexToRgba(node.colour, active ? .5 : .13);
+      context.lineWidth = 1;
+      context.beginPath();
+      context.arc(node.displayX, node.displayY, radius + (active ? 19 : 11), 0, Math.PI * 2);
+      context.stroke();
+
+      const glow = context.createRadialGradient(node.displayX, node.displayY, 2, node.displayX, node.displayY, radius * 2.3);
+      glow.addColorStop(0, hexToRgba(node.colour, active ? .68 : .38));
+      glow.addColorStop(1, hexToRgba(node.colour, 0));
+      context.fillStyle = glow;
+      context.beginPath();
+      context.arc(node.displayX, node.displayY, radius * 2.3, 0, Math.PI * 2);
+      context.fill();
+
+      context.fillStyle = node.colour;
+      context.beginPath();
+      context.arc(node.displayX, node.displayY, radius, 0, Math.PI * 2);
+      context.fill();
+
+      context.fillStyle = "rgba(12,13,19,.88)";
+      context.beginPath();
+      context.arc(node.displayX, node.displayY, Math.max(8, radius - 9), 0, Math.PI * 2);
+      context.fill();
+
+      context.fillStyle = node.colour;
+      context.beginPath();
+      context.arc(node.displayX, node.displayY, active ? 7 : 5, 0, Math.PI * 2);
+      context.fill();
+
+      if (width >= 720 || active) {
+        context.font = `${active ? 700 : 600} ${active ? 12 : 10}px "DM Sans", sans-serif`;
+        const textWidth = context.measureText(node.short).width;
+        const labelWidth = textWidth + 22;
+        const labelX = node.displayX - labelWidth / 2;
+        const labelY = node.displayY + radius + 17;
+        roundedRect(labelX, labelY, labelWidth, 27, 13.5);
+        context.fillStyle = active ? "rgba(247,247,242,.96)" : "rgba(22,23,31,.78)";
+        context.fill();
+        context.fillStyle = active ? "#171820" : "rgba(255,255,255,.78)";
+        context.textAlign = "center";
+        context.textBaseline = "middle";
+        context.fillText(node.short, node.displayX, labelY + 13.5);
+      }
+    });
+
+    if (!prefersReducedMotion) animationFrame = requestAnimationFrame(draw);
+  };
+
+  resize();
+  selectProject(0, true);
+  if (prefersReducedMotion) draw(performance.now());
+  else animationFrame = requestAnimationFrame(draw);
+
+  window.addEventListener("pagehide", () => cancelAnimationFrame(animationFrame), { once:true });
+})();

--- a/index.html
+++ b/index.html
@@ -4,20 +4,51 @@ title: Projects
 ---
 
 <main>
-  <section class="hero shell">
-    <div class="hero-copy">
-      <p class="kicker">Independent web projects</p>
-      <h1>Useful things.<br><span>Playful things.</span></h1>
-      <p class="hero-intro">A collection of games, tools and experiments made to solve a problem, explore an idea or simply see if it can be done.</p>
-      <div class="hero-actions"><a class="button button-dark" href="#projects">Explore projects</a><a class="text-link" href="{{ site.baseurl }}/blog/">Visit the old R blog <span>→</span></a></div>
+  <!-- ============================================================
+       01. LIVING PROJECT MAP
+       ============================================================ -->
+  <section class="project-universe" id="top" aria-labelledby="universe-title">
+    <canvas id="universe-canvas" aria-hidden="true"></canvas>
+    <div class="universe-grid" aria-hidden="true"></div>
+    <div class="universe-glow universe-glow-one" aria-hidden="true"></div>
+    <div class="universe-glow universe-glow-two" aria-hidden="true"></div>
+
+    <div class="universe-shell shell">
+      <div class="universe-copy">
+        <p class="universe-kicker"><span></span> Independent web projects · Move to explore</p>
+        <h1 id="universe-title">Things built to<br><em>understand things.</em></h1>
+        <p class="universe-intro">Maps, games, evidence tools and experiments. Each one starts with a question and follows it further than a normal webpage usually would.</p>
+        <div class="universe-actions"><a class="universe-button" href="#projects">Enter the collection <span>↓</span></a><a class="universe-text-link" href="#directory">See everything <span>↗</span></a></div>
+        <div class="universe-themes" aria-label="Project themes"><span>Systems</span><span>Evidence</span><span>Maps</span><span>Games</span></div>
+      </div>
+
+      <aside class="universe-panel" id="universe-panel" aria-live="polite">
+        <div class="universe-panel-top"><span class="universe-panel-index" id="universe-panel-index">01 / 09</span><span class="universe-panel-type" id="universe-panel-type">Interactive systems map</span></div>
+        <h2 id="universe-panel-title">Population Health: The Whole System</h2>
+        <p id="universe-panel-description">Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.</p>
+        <div class="universe-panel-actions"><a id="universe-panel-link" href="https://pelld.github.io/population-health-system-explorer/">Open project <span>↗</span></a>
+          <div class="universe-accessible-list" aria-label="Select a featured project">
+            <button type="button" data-project="0">Population Health: The Whole System</button>
+            <button type="button" data-project="1">Population Health: Size of the Prize</button>
+            <button type="button" data-project="2">Population Health Atlas</button>
+            <button type="button" data-project="3">P-Value Explorer</button>
+            <button type="button" data-project="4">Where Is the Art?</button>
+            <button type="button" data-project="5">Quiz Duel Stars</button>
+            <button type="button" data-project="6">Amelia in Nepal</button>
+            <button type="button" data-project="7">Hunter's Dirt Bike Adventure</button>
+            <button type="button" data-project="8">Animal Dash</button>
+          </div>
+        </div>
+      </aside>
     </div>
-    <div class="hero-graphic" aria-hidden="true">
-      <div class="orbit orbit-one"></div><div class="orbit orbit-two"></div>
-      <div class="shape shape-purple">?</div><div class="shape shape-green">↗</div><div class="shape shape-orange">✦</div>
-      <div class="graphic-card"><span>Currently exploring</span><strong>art · maps · games</strong></div>
-    </div>
+
+    <div class="universe-instruction" aria-hidden="true"><span class="universe-mouse"></span><p><strong>Move through the system</strong><br>Select a project node to bring it forward</p></div>
+    <div class="universe-counter" aria-hidden="true"><span id="universe-active-number">01</span><i></i><span>09</span></div>
   </section>
 
+  <!-- ============================================================
+       02. FEATURED PROJECT
+       ============================================================ -->
   <section class="work shell" id="projects">
     <div class="section-title"><div><p class="kicker">Featured project</p><h2>Find art anywhere.</h2></div><p>Search by artist to discover where their work is held, or start with a place to see what is nearby.</p></div>
     <a class="feature-card" href="https://pelld.github.io/where-is-the-art/">
@@ -27,7 +58,7 @@ title: Projects
   </section>
 
   <!-- ============================================================
-       02. HEALTH, EVIDENCE AND SYSTEMS
+       03. HEALTH, EVIDENCE AND SYSTEMS
        ============================================================ -->
   <section class="insights-section" id="insights">
     <div class="shell">
@@ -55,7 +86,7 @@ title: Projects
   </section>
 
   <!-- ============================================================
-       03. BURTREE GAMING STUDIOS
+       04. BURTREE GAMING STUDIOS
        ============================================================ -->
   <section class="games-section" id="games">
     <div class="shell">
@@ -71,7 +102,7 @@ title: Projects
   </section>
 
   <!-- ============================================================
-       04. AUTOMATIC SITE DIRECTORY
+       05. AUTOMATIC SITE DIRECTORY
        ============================================================ -->
   <section class="directory shell" id="directory">
     <div class="section-title"><div><p class="kicker">All public sites</p><h2>The complete directory.</h2></div><p>This list is read from GitHub automatically, so newly published public Pages sites can appear without rebuilding the homepage.</p></div>
@@ -80,9 +111,10 @@ title: Projects
   </section>
 
   <!-- ============================================================
-       05. BLOG ARCHIVE
+       06. BLOG ARCHIVE
        ============================================================ -->
   <section class="archive shell" id="archive"><div class="archive-number">2016</div><div class="archive-copy"><p class="kicker">Still here, safely archived</p><h2>Jarb: Just another R blog</h2><p>The original collection of short notes on R, SQL, SAS and coding problems. The blog and all its original posts remain available.</p></div><a class="button button-light" href="{{ site.baseurl }}/blog/">Browse the archive →</a></section>
 </main>
 
+<script src="{{ site.baseurl }}/home-universe.js" defer></script>
 <script src="{{ site.baseurl }}/site-directory.js" defer></script>


### PR DESCRIPTION
## What changed

- replaces the conventional homepage hero with a full-screen interactive project network
- connects nine featured projects by theme and lets visitors hover, click or use the panel controls to explore them
- adds a live project detail panel and direct links without removing the existing project sections below
- includes responsive mobile behaviour and a reduced-motion mode
- keeps the experiment isolated in separate CSS and JavaScript files

## Why

The current homepage is polished but still follows a standard portfolio pattern. This experiment tests a more distinctive idea: making the homepage itself an interactive project that demonstrates what a GitHub Pages site can do.

## Validation

- JavaScript syntax checked with `node --check`
- branch is four commits ahead of `master` and contains changes only to the homepage layout and new living-map assets
- existing featured projects, games, automatic directory and blog archive remain in place

This is deliberately a draft so the visual direction can be judged before anything reaches the live homepage.