### PR TITLE
Rebuild the homepage as an interactive question field

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/home-universe.css">
   </head>
   <body>
-    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#insights">Health &amp; evidence</a><a href="#games">Games</a><a href="#directory">All sites</a><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
+    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#insights">Health &amp; evidence</a><a href="#games">Games</a><button type="button" class="nav-directory" data-directory-open>All sites</button><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
     {{ content }}
     <footer class="home-footer"><div class="shell"><a class="wordmark footer-mark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><p>Games, tools and experiments.</p><a href="https://github.com/pelld">View code on GitHub ↗</a></div></footer>
   </body>

--- a/home-universe.css
+++ b/home-universe.css
@@ -1,100 +1,108 @@
 /* ============================================================
    00. LIVING PROJECT MAP — SHARED VARIABLES
    ============================================================ */
-.project-universe { --universe-paper:#f7f7f2; --universe-ink:#0d0e13; --universe-muted:rgba(245,246,242,.62); position:relative; min-height:calc(100vh - 92px); overflow:hidden; color:var(--universe-paper); background:#0d0e13; isolation:isolate; }
-.project-universe:after { position:absolute; z-index:1; inset:0; content:""; pointer-events:none; background:linear-gradient(90deg,rgba(13,14,19,.92) 0%,rgba(13,14,19,.78) 35%,rgba(13,14,19,.08) 67%,rgba(13,14,19,.28) 100%),linear-gradient(180deg,rgba(13,14,19,.05),rgba(13,14,19,.35)); }
+.project-universe { --universe-paper:#f7f7f2; --universe-ink:#0d0e13; --universe-muted:rgba(245,246,242,.62); position:relative; min-height:calc(100svh - 92px); overflow:hidden; color:var(--universe-paper); background:#0d0e13; isolation:isolate; }
+.project-universe:after { position:absolute; z-index:1; inset:0; content:""; pointer-events:none; background:linear-gradient(90deg,rgba(13,14,19,.98) 0%,rgba(13,14,19,.94) 34%,rgba(13,14,19,.66) 49%,rgba(13,14,19,.06) 72%,rgba(13,14,19,.18) 100%),linear-gradient(180deg,rgba(13,14,19,.02),rgba(13,14,19,.3)); }
 #universe-canvas { position:absolute; z-index:0; inset:0; width:100%; height:100%; touch-action:pan-y; }
-.universe-grid { position:absolute; z-index:0; inset:0; opacity:.12; background-image:linear-gradient(rgba(255,255,255,.08) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.08) 1px,transparent 1px); background-size:64px 64px; mask-image:linear-gradient(to right,transparent 0%,black 42%,black 100%); }
-.universe-glow { position:absolute; z-index:0; width:620px; height:620px; pointer-events:none; border-radius:50%; filter:blur(100px); opacity:.12; }
-.universe-glow-one { top:-260px; right:8%; background:#7657db; }
-.universe-glow-two { right:-260px; bottom:-330px; background:#55d4a9; }
+.universe-grid { position:absolute; z-index:0; inset:0; opacity:.07; background-image:linear-gradient(rgba(255,255,255,.08) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.08) 1px,transparent 1px); background-size:72px 72px; mask-image:linear-gradient(to right,transparent 0%,transparent 46%,black 70%,black 100%); }
+.universe-glow { position:absolute; z-index:0; width:560px; height:560px; pointer-events:none; border-radius:50%; filter:blur(110px); opacity:.09; }
+.universe-glow-one { top:-270px; right:10%; background:#7657db; }
+.universe-glow-two { right:-280px; bottom:-340px; background:#55d4a9; }
 
 /* ============================================================
    01. PRIMARY COPY AND LAYOUT
    ============================================================ */
-.universe-shell { position:relative; z-index:2; display:grid; min-height:calc(100vh - 92px); grid-template-columns:minmax(0,1fr) minmax(340px,.66fr); align-items:center; gap:70px; padding-block:72px 92px; pointer-events:none; }
-.universe-copy { max-width:760px; align-self:center; pointer-events:none; }
-.universe-kicker { display:flex; align-items:center; gap:10px; margin:0 0 28px; color:rgba(255,255,255,.66); font-size:11px; font-weight:800; letter-spacing:1.6px; text-transform:uppercase; }
-.universe-kicker span { width:7px; height:7px; background:#c8f169; border-radius:50%; box-shadow:0 0 0 6px rgba(200,241,105,.09),0 0 22px rgba(200,241,105,.55); }
-.universe-copy h1 { max-width:800px; margin:0; font-family:"Manrope",sans-serif; font-size:clamp(64px,7.2vw,112px); line-height:.87; letter-spacing:-7px; text-wrap:balance; }
-.universe-copy h1 em { color:transparent; font-style:normal; -webkit-text-stroke:1.5px rgba(247,247,242,.82); text-stroke:1.5px rgba(247,247,242,.82); }
-.universe-intro { max-width:620px; margin:33px 0 0; color:var(--universe-muted); font-size:18px; line-height:1.65; }
-.universe-actions { display:flex; align-items:center; gap:28px; margin-top:35px; pointer-events:auto; }
-.universe-button { display:inline-flex; align-items:center; gap:24px; padding:16px 19px 16px 22px; color:#111218; background:#c8f169; border-radius:999px; font-size:13px; font-weight:800; transition:transform .2s,box-shadow .2s; }
-.universe-button:hover { transform:translateY(-2px); box-shadow:0 14px 35px rgba(200,241,105,.18); }
-.universe-button span { display:grid; width:27px; height:27px; color:white; background:#111218; border-radius:50%; place-items:center; }
-.universe-text-link { color:rgba(255,255,255,.78); font-size:13px; font-weight:700; }
+.universe-shell { position:relative; z-index:2; display:grid; min-height:calc(100svh - 92px); grid-template-columns:minmax(0,.95fr) minmax(330px,.55fr); align-items:center; gap:90px; padding-block:76px 72px; pointer-events:none; }
+.universe-copy { max-width:680px; align-self:center; pointer-events:none; }
+.universe-kicker { display:flex; align-items:center; gap:10px; margin:0 0 27px; color:rgba(255,255,255,.62); font-size:10px; font-weight:800; letter-spacing:1.55px; text-transform:uppercase; }
+.universe-kicker span { width:7px; height:7px; background:#c8f169; border-radius:50%; box-shadow:0 0 0 6px rgba(200,241,105,.08),0 0 18px rgba(200,241,105,.45); }
+.universe-copy h1 { max-width:680px; margin:0; font-family:"Manrope",sans-serif; font-size:clamp(58px,5.5vw,88px); line-height:.91; letter-spacing:-5.2px; }
+.universe-copy h1 em { display:block; color:transparent; font-size:.82em; font-style:normal; white-space:nowrap; -webkit-text-stroke:1.35px rgba(247,247,242,.82); text-stroke:1.35px rgba(247,247,242,.82); }
+.universe-intro { max-width:540px; margin:29px 0 0; color:var(--universe-muted); font-size:16px; line-height:1.62; }
+.universe-actions { display:flex; align-items:center; gap:25px; margin-top:31px; pointer-events:auto; }
+.universe-button { display:inline-flex; align-items:center; gap:20px; padding:14px 17px 14px 20px; color:#111218; background:#c8f169; border-radius:999px; font-size:12px; font-weight:800; transition:transform .2s,box-shadow .2s; }
+.universe-button:hover { transform:translateY(-2px); box-shadow:0 14px 35px rgba(200,241,105,.16); }
+.universe-button span { display:grid; width:25px; height:25px; color:white; background:#111218; border-radius:50%; place-items:center; }
+.universe-text-link,.home-header .nav-directory { padding:0; color:inherit; background:none; border:0; font:inherit; cursor:pointer; }
+.universe-text-link { color:rgba(255,255,255,.72); font-size:12px; font-weight:700; }
 .universe-text-link span { margin-left:6px; }
-.universe-themes { display:flex; flex-wrap:wrap; gap:8px; margin-top:35px; }
-.universe-themes span { padding:7px 10px; color:rgba(255,255,255,.48); border:1px solid rgba(255,255,255,.13); border-radius:999px; font-size:10px; font-weight:700; letter-spacing:.8px; text-transform:uppercase; }
 
 /* ============================================================
    02. SELECTED PROJECT PANEL
    ============================================================ */
-.universe-panel { width:min(100%,390px); align-self:end; justify-self:end; padding:24px 25px 22px; pointer-events:auto; background:rgba(22,23,31,.72); border:1px solid rgba(255,255,255,.14); border-radius:20px; box-shadow:0 24px 70px rgba(0,0,0,.28); backdrop-filter:blur(18px); }
-.universe-panel-top { display:flex; align-items:center; justify-content:space-between; gap:18px; }
-.universe-panel-index { color:#c8f169; font:800 11px "Manrope",sans-serif; letter-spacing:1.2px; }
-.universe-panel-type { overflow:hidden; color:rgba(255,255,255,.48); font-size:9px; font-weight:800; letter-spacing:1px; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
-.universe-panel h2 { margin:26px 0 12px; font:800 27px/1.05 "Manrope",sans-serif; letter-spacing:-1.2px; }
-.universe-panel > p { min-height:66px; margin:0; color:rgba(255,255,255,.58); font-size:13px; line-height:1.55; }
-.universe-panel-actions { display:flex; align-items:center; justify-content:space-between; gap:18px; margin-top:21px; }
-#universe-panel-link { color:white; font-size:12px; font-weight:800; }
-#universe-panel-link span { display:inline-grid; width:24px; height:24px; margin-left:7px; color:#111218; background:#c8f169; border-radius:50%; place-items:center; }
-.universe-accessible-list { display:flex; align-items:center; gap:5px; }
-.universe-accessible-list button { position:relative; width:8px; height:8px; padding:0; overflow:hidden; color:transparent; background:rgba(255,255,255,.24); border:0; border-radius:50%; cursor:pointer; transition:width .18s,background .18s; }
-.universe-accessible-list button[aria-pressed="true"] { width:22px; background:#c8f169; border-radius:999px; }
+.universe-panel { width:min(100%,350px); align-self:end; justify-self:end; padding:20px 21px 19px; pointer-events:auto; background:rgba(22,23,31,.76); border:1px solid rgba(255,255,255,.12); border-radius:17px; box-shadow:0 20px 60px rgba(0,0,0,.25); backdrop-filter:blur(18px); }
+.universe-panel-top { display:flex; align-items:center; justify-content:space-between; gap:16px; }
+.universe-panel-index { color:#c8f169; font:800 10px "Manrope",sans-serif; letter-spacing:1.1px; }
+.universe-panel-type { overflow:hidden; color:rgba(255,255,255,.43); font-size:8px; font-weight:800; letter-spacing:.9px; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
+.universe-panel h2 { margin:21px 0 10px; font:800 22px/1.08 "Manrope",sans-serif; letter-spacing:-.8px; }
+.universe-panel > p { min-height:55px; margin:0; color:rgba(255,255,255,.54); font-size:12px; line-height:1.5; }
+.universe-panel-actions { display:flex; align-items:center; justify-content:space-between; gap:15px; margin-top:17px; }
+#universe-panel-link { color:white; font-size:11px; font-weight:800; }
+#universe-panel-link span { display:inline-grid; width:22px; height:22px; margin-left:6px; color:#111218; background:#c8f169; border-radius:50%; place-items:center; }
+.universe-accessible-list { display:flex; align-items:center; gap:4px; }
+.universe-accessible-list button { position:relative; width:6px; height:6px; padding:0; overflow:hidden; color:transparent; background:rgba(255,255,255,.22); border:0; border-radius:50%; cursor:pointer; transition:width .18s,background .18s; }
+.universe-accessible-list button[aria-pressed="true"] { width:18px; background:#c8f169; border-radius:999px; }
 .universe-accessible-list button:focus-visible { outline:2px solid white; outline-offset:3px; }
 
 /* ============================================================
-   03. EDGE DETAILS
+   03. ALL-SITES DRAWER
    ============================================================ */
-.universe-instruction { position:absolute; z-index:3; left:max(24px,calc((100vw - 1180px)/2)); bottom:27px; display:flex; align-items:center; gap:13px; color:rgba(255,255,255,.38); pointer-events:none; }
-.universe-instruction p { margin:0; font-size:9px; line-height:1.5; letter-spacing:.6px; text-transform:uppercase; }
-.universe-instruction strong { color:rgba(255,255,255,.7); font-weight:800; }
-.universe-mouse { position:relative; width:22px; height:32px; border:1px solid rgba(255,255,255,.35); border-radius:12px; }
-.universe-mouse:after { position:absolute; width:2px; height:6px; top:6px; left:9px; content:""; background:#c8f169; border-radius:999px; animation:universe-wheel 1.8s ease-in-out infinite; }
-.universe-counter { position:absolute; z-index:3; right:max(24px,calc((100vw - 1180px)/2)); top:28px; display:flex; align-items:center; gap:10px; color:rgba(255,255,255,.38); font:700 9px "Manrope",sans-serif; letter-spacing:1px; }
-.universe-counter span:first-child { color:white; }
-.universe-counter i { display:block; width:50px; height:1px; background:rgba(255,255,255,.2); }
-@keyframes universe-wheel { 0%,100% { opacity:.2; transform:translateY(0); } 45% { opacity:1; } 75% { opacity:0; transform:translateY(10px); } }
+body.directory-open { overflow:hidden; }
+.directory-drawer-layer { position:fixed; z-index:100; inset:0; pointer-events:none; }
+.directory-scrim { position:absolute; inset:0; width:100%; height:100%; padding:0; background:rgba(10,11,15,.46); border:0; opacity:0; cursor:pointer; transition:opacity .24s ease; }
+.directory-drawer { position:absolute; top:0; right:0; display:flex; width:min(460px,100%); height:100%; padding:34px 34px 24px; flex-direction:column; color:#171820; background:#f6f4ef; box-shadow:-25px 0 70px rgba(10,11,15,.22); transform:translateX(102%); transition:transform .3s cubic-bezier(.22,.7,.24,1); }
+body.directory-open .directory-drawer-layer { pointer-events:auto; }
+body.directory-open .directory-scrim { opacity:1; }
+body.directory-open .directory-drawer { transform:translateX(0); }
+.directory-drawer-header { display:flex; align-items:flex-start; justify-content:space-between; gap:24px; }
+.directory-drawer-header p { margin:0 0 8px; color:#7657db; font-size:10px; font-weight:800; letter-spacing:1.4px; text-transform:uppercase; }
+.directory-drawer-header h2 { margin:0; font:800 42px/1 "Manrope",sans-serif; letter-spacing:-2px; }
+.directory-close { display:grid; width:38px; height:38px; padding:0; color:#171820; background:transparent; border:1px solid #d2cec4; border-radius:50%; place-items:center; font-size:24px; line-height:1; cursor:pointer; }
+.directory-search-label { margin-top:31px; color:#6e7078; font-size:10px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
+.directory-search { width:100%; margin-top:8px; padding:13px 0; color:#171820; background:transparent; border:0; border-bottom:1px solid #cfcac0; border-radius:0; outline:none; font:600 15px "DM Sans",sans-serif; }
+.directory-search:focus { border-bottom-color:#7657db; }
+.directory-list { flex:1; margin-top:18px; overflow:auto; border-top:1px solid #ded9cf; }
+.directory-drawer .directory-card { display:grid; min-height:0; padding:17px 2px; grid-template-columns:1fr auto; gap:4px 16px; background:transparent; border:0; border-bottom:1px solid #ded9cf; border-radius:0; transform:none; }
+.directory-drawer .directory-card:hover { border-color:#b8b0ce; transform:none; }
+.directory-drawer .directory-card span { grid-column:1; color:#7657db; font-size:8px; letter-spacing:.9px; }
+.directory-drawer .directory-card h3 { grid-column:1; margin:1px 0 0; font:800 17px/1.2 "Manrope",sans-serif; letter-spacing:-.35px; }
+.directory-drawer .directory-card p { grid-column:1; margin:2px 0 0; color:#6b6d75; font-size:11px; line-height:1.4; }
+.directory-drawer .directory-card b { grid-column:2; grid-row:1/4; align-self:center; margin:0; padding:0; font-size:0; }
+.directory-drawer .directory-card b:after { content:"↗"; font-size:16px; }
+.directory-drawer .directory-loading,.directory-drawer .directory-error { padding:20px 0; color:#6b6d75; background:transparent; border:0; border-radius:0; }
+.directory-drawer-note { margin:17px 0 0; color:#85868c; font-size:10px; line-height:1.45; }
 
 /* ============================================================
    04. TABLET AND MOBILE
    ============================================================ */
 @media(max-width:980px) {
-  .project-universe:after { background:linear-gradient(180deg,rgba(13,14,19,.96) 0%,rgba(13,14,19,.76) 43%,rgba(13,14,19,.08) 70%,rgba(13,14,19,.44) 100%); }
-  .universe-shell { min-height:900px; grid-template-columns:1fr; align-items:start; gap:40px; padding-top:70px; }
-  .universe-copy { max-width:760px; }
-  .universe-copy h1 { max-width:720px; }
-  .universe-panel { width:min(100%,430px); align-self:end; justify-self:end; }
-  .universe-instruction { display:none; }
+  .project-universe:after { background:linear-gradient(180deg,rgba(13,14,19,.98) 0%,rgba(13,14,19,.9) 43%,rgba(13,14,19,.16) 70%,rgba(13,14,19,.42) 100%); }
+  .universe-shell { min-height:860px; grid-template-columns:1fr; align-items:start; gap:34px; padding-top:62px; }
+  .universe-copy { max-width:700px; }
+  .universe-panel { width:min(100%,390px); align-self:end; justify-self:end; }
 }
 
 @media(max-width:560px) {
-  .project-universe { min-height:910px; }
-  .universe-grid { background-size:42px 42px; }
-  .universe-shell { min-height:910px; gap:25px; padding-block:42px 34px; }
-  .universe-kicker { margin-bottom:22px; font-size:9px; letter-spacing:1.2px; }
-  .universe-copy h1 { font-size:52px; line-height:.92; letter-spacing:-3.8px; }
-  .universe-copy h1 em { -webkit-text-stroke-width:1px; }
-  .universe-intro { max-width:94%; margin-top:24px; font-size:15px; line-height:1.55; }
-  .universe-actions { align-items:flex-start; flex-direction:column; gap:17px; margin-top:27px; }
-  .universe-button { padding:13px 16px 13px 18px; }
-  .universe-themes { margin-top:24px; }
-  .universe-panel { width:100%; padding:20px; border-radius:17px; }
-  .universe-panel h2 { margin-top:20px; font-size:23px; }
-  .universe-panel > p { min-height:60px; }
-  .universe-panel-actions { gap:12px; }
-  .universe-accessible-list { gap:4px; }
-  .universe-accessible-list button { width:7px; height:7px; }
-  .universe-accessible-list button[aria-pressed="true"] { width:17px; }
-  .universe-counter { display:none; }
+  .project-universe { min-height:860px; }
+  .universe-grid { background-size:46px 46px; }
+  .universe-shell { min-height:860px; gap:24px; padding-block:42px 30px; }
+  .universe-kicker { margin-bottom:20px; font-size:9px; letter-spacing:1.15px; }
+  .universe-copy h1 { font-size:50px; line-height:.94; letter-spacing:-3.6px; }
+  .universe-copy h1 em { font-size:.86em; white-space:normal; -webkit-text-stroke-width:1px; }
+  .universe-intro { max-width:95%; margin-top:22px; font-size:14px; line-height:1.55; }
+  .universe-actions { align-items:flex-start; flex-direction:column; gap:15px; margin-top:25px; }
+  .universe-button { padding:12px 15px 12px 17px; }
+  .universe-panel { width:100%; padding:18px; border-radius:15px; }
+  .universe-panel h2 { margin-top:17px; font-size:20px; }
+  .universe-panel > p { min-height:52px; }
+  .universe-panel-actions { gap:10px; }
+  .directory-drawer { padding:26px 22px 20px; }
+  .directory-drawer-header h2 { font-size:36px; }
 }
 
 /* ============================================================
    05. ACCESSIBILITY AND LOW-MOTION MODE
    ============================================================ */
 @media(prefers-reduced-motion:reduce) {
-  .universe-mouse:after { animation:none; }
-  .universe-button,.universe-accessible-list button { transition:none; }
+  .universe-button,.universe-accessible-list button,.directory-scrim,.directory-drawer { transition:none; }
 }

--- a/home-universe.js
+++ b/home-universe.js
@@ -2,18 +2,18 @@
    00. PROJECT DATA
    ============================================================ */
 const universeProjects = [
-  { title:"Population Health: The Whole System", short:"Whole system", type:"Interactive systems map", description:"Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.", url:"https://pelld.github.io/population-health-system-explorer/", colour:"#71e2bd", x:.67, y:.25, radius:38 },
-  { title:"Population Health: Size of the Prize", short:"Size of the prize", type:"Decision support prototype", description:"Explore how interventions affect the whole person and compare health, financial and societal returns.", url:"https://pelld.github.io/population-health-size-of-prize/", colour:"#d9f279", x:.84, y:.38, radius:31 },
-  { title:"Population Health Atlas", short:"Health atlas", type:"Geographic analysis", description:"Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.", url:"https://pelld.github.io/population-health-atlas/", colour:"#78b9ef", x:.73, y:.57, radius:34 },
-  { title:"P-Value Explorer", short:"P-value explorer", type:"PubMed evidence explorer", description:"Search abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.", url:"https://pelld.github.io/p-value-explorer/", colour:"#aa8df4", x:.91, y:.68, radius:29 },
-  { title:"Where Is the Art?", short:"Where is the art?", type:"Interactive art map", description:"Search by artist or place to discover where artworks are held and what can be seen nearby.", url:"https://pelld.github.io/where-is-the-art/", colour:"#ff9775", x:.56, y:.72, radius:40 },
-  { title:"Quiz Duel Stars", short:"Quiz duel", type:"Two-device game", description:"Fast head-to-head trivia played together from different phones and different locations.", url:"https://pelld.github.io/quiz-duel-stars/", colour:"#f3d864", x:.42, y:.48, radius:30 },
-  { title:"Amelia in Nepal", short:"Amelia in Nepal", type:"Personal adventure", description:"A personalised journey through the mountains, built as a playable web adventure.", url:"https://pelld.github.io/amelia-nepal-game/", colour:"#80d9c8", x:.47, y:.23, radius:27 },
-  { title:"Hunter's Dirt Bike Adventure", short:"Dirt bike adventure", type:"Action game", description:"Ride, jump and perform tricks across a game-world inspired by the North Pennines.", url:"https://pelld.github.io/hunter-dirt-bike-adventure/", colour:"#eeb06f", x:.30, y:.68, radius:31 },
-  { title:"Animal Dash", short:"Animal dash", type:"Arcade game", description:"A bright and simple action game designed for younger players and quick bursts of play.", url:"https://pelld.github.io/animal-dash/", colour:"#ef8db3", x:.24, y:.35, radius:26 }
+  { title:"Population Health: The Whole System", short:"Whole system", type:"Interactive systems map", description:"Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.", url:"https://pelld.github.io/population-health-system-explorer/", colour:"#71e2bd", x:.66, y:.22, radius:28 },
+  { title:"Population Health: Size of the Prize", short:"Size of the prize", type:"Decision support prototype", description:"Explore how interventions affect the whole person and compare health, financial and societal returns.", url:"https://pelld.github.io/population-health-size-of-prize/", colour:"#d9f279", x:.9, y:.31, radius:25 },
+  { title:"Population Health Atlas", short:"Health atlas", type:"Geographic analysis", description:"Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.", url:"https://pelld.github.io/population-health-atlas/", colour:"#78b9ef", x:.76, y:.52, radius:27 },
+  { title:"P-Value Explorer", short:"P-value explorer", type:"PubMed evidence explorer", description:"Search abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.", url:"https://pelld.github.io/p-value-explorer/", colour:"#aa8df4", x:.94, y:.61, radius:23 },
+  { title:"Where Is the Art?", short:"Where is the art?", type:"Interactive art map", description:"Search by artist or place to discover where artworks are held and what can be seen nearby.", url:"https://pelld.github.io/where-is-the-art/", colour:"#ff9775", x:.62, y:.65, radius:31 },
+  { title:"Quiz Duel Stars", short:"Quiz duel", type:"Two-device game", description:"Fast head-to-head trivia played together from different phones and different locations.", url:"https://pelld.github.io/quiz-duel-stars/", colour:"#f3d864", x:.49, y:.46, radius:24 },
+  { title:"Amelia in Nepal", short:"Amelia in Nepal", type:"Personal adventure", description:"A personalised journey through the mountains, built as a playable web adventure.", url:"https://pelld.github.io/amelia-nepal-game/", colour:"#80d9c8", x:.48, y:.2, radius:22 },
+  { title:"Hunter's Dirt Bike Adventure", short:"Dirt bike adventure", type:"Action game", description:"Ride, jump and perform tricks across a game-world inspired by the North Pennines.", url:"https://pelld.github.io/hunter-dirt-bike-adventure/", colour:"#eeb06f", x:.4, y:.67, radius:25 },
+  { title:"Animal Dash", short:"Animal dash", type:"Arcade game", description:"A bright and simple action game designed for younger players and quick bursts of play.", url:"https://pelld.github.io/animal-dash/", colour:"#ef8db3", x:.31, y:.35, radius:21 }
 ];
 
-const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,6],[4,7],[5,6],[5,7],[5,8],[6,8],[7,8]];
+const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,6],[5,6],[5,7],[5,8],[7,8]];
 
 /* ============================================================
    01. INITIALISE THE CANVAS AND INTERFACE
@@ -29,7 +29,6 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
   const panelTitle = document.getElementById("universe-panel-title");
   const panelDescription = document.getElementById("universe-panel-description");
   const panelLink = document.getElementById("universe-panel-link");
-  const activeNumber = document.getElementById("universe-active-number");
   const accessibleButtons = [...document.querySelectorAll(".universe-accessible-list button")];
   const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
@@ -41,12 +40,14 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
   let pointer = { x:-1000, y:-1000, active:false };
   let scrollProgress = 0;
   let animationFrame = 0;
-  let startTime = performance.now();
+  const startTime = performance.now();
 
-  const nodes = universeProjects.map((project, index) => ({ ...project, index, px:0, py:0, displayX:0, displayY:0, velocityX:0, velocityY:0 }));
+  const nodes = universeProjects.map((project, index) => ({ ...project, index, px:0, py:0, displayX:0, displayY:0 }));
 
   /* ============================================================
      02. RESIZE AND POSITION NODES
+     Desktop nodes are deliberately constrained to the right so
+     the graphic supports the headline rather than crossing it.
      ============================================================ */
   const resize = () => {
     const bounds = universe.getBoundingClientRect();
@@ -61,8 +62,8 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
 
     nodes.forEach(node => {
       const mobile = width < 720;
-      node.px = mobile ? width * (.12 + node.x * .76) : width * node.x;
-      node.py = mobile ? height * (.39 + node.y * .49) : height * node.y;
+      node.px = mobile ? width * (.1 + node.x * .8) : width * (.54 + node.x * .43);
+      node.py = mobile ? height * (.4 + node.y * .45) : height * (.08 + node.y * .76);
       if (!node.displayX) { node.displayX = node.px; node.displayY = node.py; }
     });
   };
@@ -79,7 +80,6 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
     panelTitle.textContent = project.title;
     panelDescription.textContent = project.description;
     panelLink.href = project.url;
-    activeNumber.textContent = String(index + 1).padStart(2, "0");
     accessibleButtons.forEach((button, buttonIndex) => button.setAttribute("aria-pressed", buttonIndex === index ? "true" : "false"));
   };
 
@@ -139,68 +139,68 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
     let closestDistance = Number.POSITIVE_INFINITY;
 
     nodes.forEach(node => {
-      const driftX = prefersReducedMotion ? 0 : Math.sin(elapsed * .48 + node.index * 1.9) * 8;
-      const driftY = prefersReducedMotion ? 0 : Math.cos(elapsed * .42 + node.index * 1.4) * 7;
-      let targetX = node.px + driftX - scrollProgress * (node.index % 2 ? 24 : -18);
-      let targetY = node.py + driftY - scrollProgress * (20 + node.index * 2);
+      const driftX = prefersReducedMotion ? 0 : Math.sin(elapsed * .42 + node.index * 1.9) * 6;
+      const driftY = prefersReducedMotion ? 0 : Math.cos(elapsed * .38 + node.index * 1.4) * 5;
+      let targetX = node.px + driftX - scrollProgress * (node.index % 2 ? 14 : -10);
+      let targetY = node.py + driftY - scrollProgress * (14 + node.index);
 
       if (pointer.active) {
         const dx = targetX - pointer.x;
         const dy = targetY - pointer.y;
         const distance = Math.hypot(dx, dy);
-        if (distance < 190 && distance > 0) {
-          const force = (190 - distance) / 190;
-          targetX += (dx / distance) * force * 30;
-          targetY += (dy / distance) * force * 30;
+        if (distance < 150 && distance > 0) {
+          const force = (150 - distance) / 150;
+          targetX += (dx / distance) * force * 20;
+          targetY += (dy / distance) * force * 20;
         }
       }
 
-      node.displayX += (targetX - node.displayX) * (prefersReducedMotion ? 1 : .055);
-      node.displayY += (targetY - node.displayY) * (prefersReducedMotion ? 1 : .055);
+      node.displayX += (targetX - node.displayX) * (prefersReducedMotion ? 1 : .06);
+      node.displayY += (targetY - node.displayY) * (prefersReducedMotion ? 1 : .06);
 
       if (pointer.active) {
         const distance = Math.hypot(node.displayX - pointer.x, node.displayY - pointer.y);
-        if (distance < node.radius + 34 && distance < closestDistance) { closestDistance = distance; hoverProject = node.index; }
+        if (distance < node.radius + 28 && distance < closestDistance) { closestDistance = distance; hoverProject = node.index; }
       }
     });
 
-    universe.style.cursor = hoverProject >= 0 ? "pointer" : "default";
+    canvas.style.cursor = hoverProject >= 0 ? "pointer" : "default";
     if (hoverProject >= 0) selectProject(hoverProject);
 
-    /* Draw connections behind the nodes. */
+    /* Draw restrained connections behind the nodes. */
     universeConnections.forEach(([fromIndex, toIndex]) => {
       const from = nodes[fromIndex];
       const to = nodes[toIndex];
       const highlighted = [fromIndex, toIndex].includes(hoverProject >= 0 ? hoverProject : selectedProject);
       const gradient = context.createLinearGradient(from.displayX, from.displayY, to.displayX, to.displayY);
-      gradient.addColorStop(0, hexToRgba(from.colour, highlighted ? .62 : .19));
-      gradient.addColorStop(1, hexToRgba(to.colour, highlighted ? .62 : .19));
+      gradient.addColorStop(0, hexToRgba(from.colour, highlighted ? .42 : .1));
+      gradient.addColorStop(1, hexToRgba(to.colour, highlighted ? .42 : .1));
       context.strokeStyle = gradient;
-      context.lineWidth = highlighted ? 1.7 : .8;
+      context.lineWidth = highlighted ? 1.3 : .65;
       context.beginPath();
       context.moveTo(from.displayX, from.displayY);
       context.lineTo(to.displayX, to.displayY);
       context.stroke();
     });
 
-    /* Draw each node, its orbit and its label. */
+    /* Only the active node receives a label. */
     nodes.forEach(node => {
       const activeIndex = hoverProject >= 0 ? hoverProject : selectedProject;
       const active = node.index === activeIndex;
-      const radius = node.radius * (active ? 1.18 : 1);
+      const radius = node.radius * (active ? 1.16 : 1);
 
-      context.strokeStyle = hexToRgba(node.colour, active ? .5 : .13);
+      context.strokeStyle = hexToRgba(node.colour, active ? .46 : .09);
       context.lineWidth = 1;
       context.beginPath();
-      context.arc(node.displayX, node.displayY, radius + (active ? 19 : 11), 0, Math.PI * 2);
+      context.arc(node.displayX, node.displayY, radius + (active ? 16 : 9), 0, Math.PI * 2);
       context.stroke();
 
-      const glow = context.createRadialGradient(node.displayX, node.displayY, 2, node.displayX, node.displayY, radius * 2.3);
-      glow.addColorStop(0, hexToRgba(node.colour, active ? .68 : .38));
+      const glow = context.createRadialGradient(node.displayX, node.displayY, 2, node.displayX, node.displayY, radius * 2.15);
+      glow.addColorStop(0, hexToRgba(node.colour, active ? .52 : .24));
       glow.addColorStop(1, hexToRgba(node.colour, 0));
       context.fillStyle = glow;
       context.beginPath();
-      context.arc(node.displayX, node.displayY, radius * 2.3, 0, Math.PI * 2);
+      context.arc(node.displayX, node.displayY, radius * 2.15, 0, Math.PI * 2);
       context.fill();
 
       context.fillStyle = node.colour;
@@ -208,29 +208,29 @@ const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,
       context.arc(node.displayX, node.displayY, radius, 0, Math.PI * 2);
       context.fill();
 
-      context.fillStyle = "rgba(12,13,19,.88)";
+      context.fillStyle = "rgba(12,13,19,.9)";
       context.beginPath();
-      context.arc(node.displayX, node.displayY, Math.max(8, radius - 9), 0, Math.PI * 2);
+      context.arc(node.displayX, node.displayY, Math.max(7, radius - 7), 0, Math.PI * 2);
       context.fill();
 
       context.fillStyle = node.colour;
       context.beginPath();
-      context.arc(node.displayX, node.displayY, active ? 7 : 5, 0, Math.PI * 2);
+      context.arc(node.displayX, node.displayY, active ? 6 : 4, 0, Math.PI * 2);
       context.fill();
 
-      if (width >= 720 || active) {
-        context.font = `${active ? 700 : 600} ${active ? 12 : 10}px "DM Sans", sans-serif`;
+      if (active) {
+        context.font = `700 ${width < 720 ? 10 : 11}px "DM Sans", sans-serif`;
         const textWidth = context.measureText(node.short).width;
-        const labelWidth = textWidth + 22;
+        const labelWidth = textWidth + 20;
         const labelX = node.displayX - labelWidth / 2;
-        const labelY = node.displayY + radius + 17;
-        roundedRect(labelX, labelY, labelWidth, 27, 13.5);
-        context.fillStyle = active ? "rgba(247,247,242,.96)" : "rgba(22,23,31,.78)";
+        const labelY = node.displayY + radius + 14;
+        roundedRect(labelX, labelY, labelWidth, 25, 12.5);
+        context.fillStyle = "rgba(247,247,242,.94)";
         context.fill();
-        context.fillStyle = active ? "#171820" : "rgba(255,255,255,.78)";
+        context.fillStyle = "#171820";
         context.textAlign = "center";
         context.textBaseline = "middle";
-        context.fillText(node.short, node.displayX, labelY + 13.5);
+        context.fillText(node.short, node.displayX, labelY + 12.5);
       }
     });
 

--- a/index.html
+++ b/index.html
@@ -15,11 +15,10 @@ title: Projects
 
     <div class="universe-shell shell">
       <div class="universe-copy">
-        <p class="universe-kicker"><span></span> Independent web projects · Move to explore</p>
+        <p class="universe-kicker"><span></span> Independent web projects</p>
         <h1 id="universe-title">Things built to<br><em>understand things.</em></h1>
-        <p class="universe-intro">Maps, games, evidence tools and experiments. Each one starts with a question and follows it further than a normal webpage usually would.</p>
-        <div class="universe-actions"><a class="universe-button" href="#projects">Enter the collection <span>↓</span></a><a class="universe-text-link" href="#directory">See everything <span>↗</span></a></div>
-        <div class="universe-themes" aria-label="Project themes"><span>Systems</span><span>Evidence</span><span>Maps</span><span>Games</span></div>
+        <p class="universe-intro">Maps, games, evidence tools and experiments. Each starts with a question and follows it further than a normal webpage usually would.</p>
+        <div class="universe-actions"><a class="universe-button" href="#projects">Explore the collection <span>↓</span></a><button type="button" class="universe-text-link" data-directory-open>All projects <span>↗</span></button></div>
       </div>
 
       <aside class="universe-panel" id="universe-panel" aria-live="polite">
@@ -41,9 +40,6 @@ title: Projects
         </div>
       </aside>
     </div>
-
-    <div class="universe-instruction" aria-hidden="true"><span class="universe-mouse"></span><p><strong>Move through the system</strong><br>Select a project node to bring it forward</p></div>
-    <div class="universe-counter" aria-hidden="true"><span id="universe-active-number">01</span><i></i><span>09</span></div>
   </section>
 
   <!-- ============================================================
@@ -102,19 +98,24 @@ title: Projects
   </section>
 
   <!-- ============================================================
-       05. AUTOMATIC SITE DIRECTORY
-       ============================================================ -->
-  <section class="directory shell" id="directory">
-    <div class="section-title"><div><p class="kicker">All public sites</p><h2>The complete directory.</h2></div><p>This list is read from GitHub automatically, so newly published public Pages sites can appear without rebuilding the homepage.</p></div>
-    <div id="site-directory" class="directory-grid" aria-live="polite"><p class="directory-loading">Looking for published sites…</p></div>
-    <p class="directory-note">The curated projects above include fuller descriptions. Login-protected and explicitly hidden projects are excluded from this public directory.</p>
-  </section>
-
-  <!-- ============================================================
-       06. BLOG ARCHIVE
+       05. BLOG ARCHIVE
        ============================================================ -->
   <section class="archive shell" id="archive"><div class="archive-number">2016</div><div class="archive-copy"><p class="kicker">Still here, safely archived</p><h2>Jarb: Just another R blog</h2><p>The original collection of short notes on R, SQL, SAS and coding problems. The blog and all its original posts remain available.</p></div><a class="button button-light" href="{{ site.baseurl }}/blog/">Browse the archive →</a></section>
 </main>
+
+<!-- ============================================================
+     06. ALL-SITES DRAWER
+     ============================================================ -->
+<div class="directory-drawer-layer" id="directory-drawer-layer" aria-hidden="true">
+  <button type="button" class="directory-scrim" data-directory-close aria-label="Close all projects"></button>
+  <aside class="directory-drawer" role="dialog" aria-modal="true" aria-labelledby="directory-title">
+    <header class="directory-drawer-header"><div><p>All public sites</p><h2 id="directory-title">Projects</h2></div><button type="button" class="directory-close" data-directory-close aria-label="Close all projects">×</button></header>
+    <label class="directory-search-label" for="directory-search">Search projects</label>
+    <input id="directory-search" class="directory-search" type="search" placeholder="Search by name or type" autocomplete="off">
+    <div id="site-directory" class="directory-list" aria-live="polite"><p class="directory-loading">Looking for published sites…</p></div>
+    <p class="directory-drawer-note">This list is generated automatically from public GitHub Pages repositories.</p>
+  </aside>
+</div>
 
 <script src="{{ site.baseurl }}/home-universe.js" defer></script>
 <script src="{{ site.baseurl }}/site-directory.js" defer></script>

--- a/site-directory.js
+++ b/site-directory.js
@@ -67,6 +67,7 @@ function pagesUrl(repository) {
 
 function renderDirectory(repositories) {
   const container = document.getElementById("site-directory");
+  if (!container) return;
   container.replaceChildren();
 
   repositories.forEach(repository => {
@@ -78,17 +79,54 @@ function renderDirectory(repositories) {
 
     card.className = "directory-card";
     card.href = pagesUrl(repository);
+    card.dataset.search = `${titleFromRepository(repository.name)} ${categoryFromRepository(repository)} ${repository.description || ""}`.toLowerCase();
     category.textContent = categoryFromRepository(repository);
     title.textContent = titleFromRepository(repository.name);
     description.textContent = repository.description || "A public GitHub Pages project.";
-    link.textContent = "Open site ↗";
+    link.textContent = "Open site";
     card.append(category, title, description, link);
     container.append(card);
   });
 }
 
 /* ============================================================
-   03. GITHUB DISCOVERY WITH STATIC FALLBACK
+   03. DRAWER INTERACTION
+   ============================================================ */
+
+function initialiseDirectoryDrawer() {
+  const layer = document.getElementById("directory-drawer-layer");
+  const search = document.getElementById("directory-search");
+  const openButtons = [...document.querySelectorAll("[data-directory-open]")];
+  const closeButtons = [...document.querySelectorAll("[data-directory-close]")];
+  if (!layer || openButtons.length === 0) return;
+
+  let lastFocusedElement = null;
+
+  const openDrawer = () => {
+    lastFocusedElement = document.activeElement;
+    document.body.classList.add("directory-open");
+    layer.setAttribute("aria-hidden", "false");
+    window.setTimeout(() => search?.focus(), 40);
+  };
+
+  const closeDrawer = () => {
+    document.body.classList.remove("directory-open");
+    layer.setAttribute("aria-hidden", "true");
+    if (lastFocusedElement instanceof HTMLElement) lastFocusedElement.focus();
+  };
+
+  openButtons.forEach(button => button.addEventListener("click", openDrawer));
+  closeButtons.forEach(button => button.addEventListener("click", closeDrawer));
+  document.addEventListener("keydown", event => { if (event.key === "Escape" && document.body.classList.contains("directory-open")) closeDrawer(); });
+
+  search?.addEventListener("input", () => {
+    const query = search.value.trim().toLowerCase();
+    document.querySelectorAll("#site-directory .directory-card").forEach(card => { card.hidden = query.length > 0 && !card.dataset.search.includes(query); });
+  });
+}
+
+/* ============================================================
+   04. GITHUB DISCOVERY WITH STATIC FALLBACK
    The fallback ensures the directory remains useful if GitHub's
    public API is temporarily unavailable or rate-limited.
    ============================================================ */
@@ -107,4 +145,5 @@ async function loadDirectory() {
   }
 }
 
+initialiseDirectoryDrawer();
 loadDirectory();


### PR DESCRIPTION
## New direction

This replaces the previous hero, canvas nodes, selection panel and all project-card sections with one coherent full-screen experience.

Every visible question is now a genuine project hyperlink. Hovering or focusing a question changes the colour, background mark, relationship lines and bottom readout; clicking it opens the project directly.

## Interaction included

- eight direct featured-project hyperlinks phrased as questions
- animated relationship lines between connected ideas
- pointer-following light, restrained parallax and magnetic link movement
- project-specific colour and large background marks
- **All / Analyse / Explore / Play** focus modes
- arrow-key navigation between visible project links
- **Ctrl/Cmd + K** project-index shortcut
- searchable automatic project drawer
- a clean mobile version that becomes a large linked question index
- reduced-motion support

## Removed

- the “Things built to understand things” slogan
- decorative canvas nodes that only selected a separate card
- featured-project cards
- health/evidence cards
- game cards
- the stacked scrolling portfolio layout

## Why

The previous versions were trying to be both a conventional portfolio and an experimental interface. This version commits to one idea: **the hyperlinks themselves are the site**. The motion and visual effects explain relationships and provide atmosphere, but navigation remains immediate and unambiguous.