### PR TITLE
Turn the homepage into a clickable project constellation

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,18 +3,27 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#0d0e13">
+    <meta name="theme-color" content="#0b0c11">
     <title>{{ page.title }} · {{ site.name }}</title>
     <meta name="description" content="{{ site.description }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Manrope:wght@500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ site.baseurl }}/home.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/home-universe.css">
   </head>
   <body>
-    <header class="home-header shell"><a class="wordmark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><nav><a href="#projects">Projects</a><a href="#insights">Health &amp; evidence</a><a href="#games">Games</a><button type="button" class="nav-directory" data-directory-open>All sites</button><a href="{{ site.baseurl }}/blog/">Archive</a><a class="nav-github" href="https://github.com/pelld">GitHub ↗</a></nav></header>
+    <header class="home-header shell">
+      <a class="wordmark" href="{{ site.baseurl }}/"><span>p</span><b>pelld</b><small>projects</small></a>
+      <nav aria-label="Project views">
+        <button type="button" class="nav-filter" data-project-filter="all" aria-pressed="true">All</button>
+        <button type="button" class="nav-filter" data-project-filter="analyse" aria-pressed="false">Analyse</button>
+        <button type="button" class="nav-filter" data-project-filter="explore" aria-pressed="false">Explore</button>
+        <button type="button" class="nav-filter" data-project-filter="play" aria-pressed="false">Play</button>
+        <button type="button" class="nav-directory" data-directory-open>Project index</button>
+        <a class="nav-archive" href="{{ site.baseurl }}/blog/">Archive</a>
+        <a class="nav-github" href="https://github.com/pelld">GitHub ↗</a>
+      </nav>
+    </header>
     {{ content }}
-    <footer class="home-footer"><div class="shell"><a class="wordmark footer-mark" href="{{ site.baseurl }}/"><span>p</span> pelld projects</a><p>Games, tools and experiments.</p><a href="https://github.com/pelld">View code on GitHub ↗</a></div></footer>
   </body>
 </html>

--- a/home-universe.css
+++ b/home-universe.css
@@ -1,108 +1,148 @@
 /* ============================================================
-   00. LIVING PROJECT MAP — SHARED VARIABLES
+   00. FOUNDATION
    ============================================================ */
-.project-universe { --universe-paper:#f7f7f2; --universe-ink:#0d0e13; --universe-muted:rgba(245,246,242,.62); position:relative; min-height:calc(100svh - 92px); overflow:hidden; color:var(--universe-paper); background:#0d0e13; isolation:isolate; }
-.project-universe:after { position:absolute; z-index:1; inset:0; content:""; pointer-events:none; background:linear-gradient(90deg,rgba(13,14,19,.98) 0%,rgba(13,14,19,.94) 34%,rgba(13,14,19,.66) 49%,rgba(13,14,19,.06) 72%,rgba(13,14,19,.18) 100%),linear-gradient(180deg,rgba(13,14,19,.02),rgba(13,14,19,.3)); }
-#universe-canvas { position:absolute; z-index:0; inset:0; width:100%; height:100%; touch-action:pan-y; }
-.universe-grid { position:absolute; z-index:0; inset:0; opacity:.07; background-image:linear-gradient(rgba(255,255,255,.08) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.08) 1px,transparent 1px); background-size:72px 72px; mask-image:linear-gradient(to right,transparent 0%,transparent 46%,black 70%,black 100%); }
-.universe-glow { position:absolute; z-index:0; width:560px; height:560px; pointer-events:none; border-radius:50%; filter:blur(110px); opacity:.09; }
-.universe-glow-one { top:-270px; right:10%; background:#7657db; }
-.universe-glow-two { right:-280px; bottom:-340px; background:#55d4a9; }
+:root { --paper:#f6f4ef; --ink:#0b0c11; --muted:rgba(246,244,239,.55); --lime:#c8f169; }
+* { box-sizing:border-box; }
+html { min-height:100%; background:var(--ink); }
+body { min-height:100%; margin:0; overflow:hidden; color:var(--paper); background:var(--ink); font-family:"DM Sans",sans-serif; -webkit-font-smoothing:antialiased; }
+a { color:inherit; text-decoration:none; }
+button,input { font:inherit; }
+.shell { width:min(1380px,calc(100% - 64px)); margin-inline:auto; }
 
 /* ============================================================
-   01. PRIMARY COPY AND LAYOUT
+   01. TRANSPARENT SITE HEADER
    ============================================================ */
-.universe-shell { position:relative; z-index:2; display:grid; min-height:calc(100svh - 92px); grid-template-columns:minmax(0,.95fr) minmax(330px,.55fr); align-items:center; gap:90px; padding-block:76px 72px; pointer-events:none; }
-.universe-copy { max-width:680px; align-self:center; pointer-events:none; }
-.universe-kicker { display:flex; align-items:center; gap:10px; margin:0 0 27px; color:rgba(255,255,255,.62); font-size:10px; font-weight:800; letter-spacing:1.55px; text-transform:uppercase; }
-.universe-kicker span { width:7px; height:7px; background:#c8f169; border-radius:50%; box-shadow:0 0 0 6px rgba(200,241,105,.08),0 0 18px rgba(200,241,105,.45); }
-.universe-copy h1 { max-width:680px; margin:0; font-family:"Manrope",sans-serif; font-size:clamp(58px,5.5vw,88px); line-height:.91; letter-spacing:-5.2px; }
-.universe-copy h1 em { display:block; color:transparent; font-size:.82em; font-style:normal; white-space:nowrap; -webkit-text-stroke:1.35px rgba(247,247,242,.82); text-stroke:1.35px rgba(247,247,242,.82); }
-.universe-intro { max-width:540px; margin:29px 0 0; color:var(--universe-muted); font-size:16px; line-height:1.62; }
-.universe-actions { display:flex; align-items:center; gap:25px; margin-top:31px; pointer-events:auto; }
-.universe-button { display:inline-flex; align-items:center; gap:20px; padding:14px 17px 14px 20px; color:#111218; background:#c8f169; border-radius:999px; font-size:12px; font-weight:800; transition:transform .2s,box-shadow .2s; }
-.universe-button:hover { transform:translateY(-2px); box-shadow:0 14px 35px rgba(200,241,105,.16); }
-.universe-button span { display:grid; width:25px; height:25px; color:white; background:#111218; border-radius:50%; place-items:center; }
-.universe-text-link,.home-header .nav-directory { padding:0; color:inherit; background:none; border:0; font:inherit; cursor:pointer; }
-.universe-text-link { color:rgba(255,255,255,.72); font-size:12px; font-weight:700; }
-.universe-text-link span { margin-left:6px; }
+.home-header { position:fixed; z-index:50; top:0; left:50%; display:flex; height:86px; align-items:center; justify-content:space-between; transform:translateX(-50%); }
+.wordmark { display:flex; align-items:center; gap:10px; color:white; font-family:"Manrope",sans-serif; font-size:15px; font-weight:800; letter-spacing:-.25px; }
+.wordmark > span { display:grid; width:32px; height:32px; color:#111218; background:var(--lime); border-radius:9px; place-items:center; font-size:18px; }
+.wordmark small { margin-left:-4px; color:rgba(255,255,255,.42); font-size:10px; font-weight:700; letter-spacing:1.2px; text-transform:uppercase; }
+.home-header nav { display:flex; align-items:center; gap:25px; }
+.home-header nav button,.home-header nav a { position:relative; padding:7px 0; color:rgba(255,255,255,.55); background:none; border:0; font-size:11px; font-weight:700; letter-spacing:.2px; cursor:pointer; transition:color .18s ease; }
+.home-header nav button:hover,.home-header nav a:hover,.home-header nav button[aria-pressed="true"] { color:white; }
+.home-header nav button[aria-pressed="true"]:after { position:absolute; right:0; bottom:0; left:0; height:1px; content:""; background:var(--lime); }
+.home-header .nav-directory { padding:9px 14px; color:white; border:1px solid rgba(255,255,255,.17); border-radius:999px; }
+.home-header .nav-github { color:white; }
 
 /* ============================================================
-   02. SELECTED PROJECT PANEL
+   02. FULL-SCREEN QUESTION STAGE
    ============================================================ */
-.universe-panel { width:min(100%,350px); align-self:end; justify-self:end; padding:20px 21px 19px; pointer-events:auto; background:rgba(22,23,31,.76); border:1px solid rgba(255,255,255,.12); border-radius:17px; box-shadow:0 20px 60px rgba(0,0,0,.25); backdrop-filter:blur(18px); }
-.universe-panel-top { display:flex; align-items:center; justify-content:space-between; gap:16px; }
-.universe-panel-index { color:#c8f169; font:800 10px "Manrope",sans-serif; letter-spacing:1.1px; }
-.universe-panel-type { overflow:hidden; color:rgba(255,255,255,.43); font-size:8px; font-weight:800; letter-spacing:.9px; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
-.universe-panel h2 { margin:21px 0 10px; font:800 22px/1.08 "Manrope",sans-serif; letter-spacing:-.8px; }
-.universe-panel > p { min-height:55px; margin:0; color:rgba(255,255,255,.54); font-size:12px; line-height:1.5; }
-.universe-panel-actions { display:flex; align-items:center; justify-content:space-between; gap:15px; margin-top:17px; }
-#universe-panel-link { color:white; font-size:11px; font-weight:800; }
-#universe-panel-link span { display:inline-grid; width:22px; height:22px; margin-left:6px; color:#111218; background:#c8f169; border-radius:50%; place-items:center; }
-.universe-accessible-list { display:flex; align-items:center; gap:4px; }
-.universe-accessible-list button { position:relative; width:6px; height:6px; padding:0; overflow:hidden; color:transparent; background:rgba(255,255,255,.22); border:0; border-radius:50%; cursor:pointer; transition:width .18s,background .18s; }
-.universe-accessible-list button[aria-pressed="true"] { width:18px; background:#c8f169; border-radius:999px; }
-.universe-accessible-list button:focus-visible { outline:2px solid white; outline-offset:3px; }
+.question-stage { --accent:#c8f169; --mx:50%; --my:50%; position:relative; min-height:100svh; overflow:hidden; background:radial-gradient(circle at 74% 42%,rgba(42,44,58,.27),transparent 32%),linear-gradient(135deg,#0a0b10 0%,#10111a 56%,#090a0e 100%); isolation:isolate; }
+.stage-light { position:absolute; z-index:0; inset:0; pointer-events:none; background:radial-gradient(circle 270px at var(--mx) var(--my),color-mix(in srgb,var(--accent) 18%,transparent),transparent 70%); opacity:.75; transition:background .28s ease; }
+.stage-grid { position:absolute; z-index:0; inset:-20%; pointer-events:none; opacity:.12; background-image:linear-gradient(rgba(255,255,255,.055) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.055) 1px,transparent 1px); background-size:74px 74px; mask-image:radial-gradient(circle at center,black,transparent 69%); transform:perspective(900px) rotateX(63deg) translateY(35%); transform-origin:center bottom; }
+.stage-grain { position:absolute; z-index:5; inset:0; pointer-events:none; opacity:.035; background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.92' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.55'/%3E%3C/svg%3E"); }
+.stage-mark { position:absolute; z-index:0; top:14%; right:3%; max-width:54vw; color:transparent; opacity:0; pointer-events:none; font:800 clamp(150px,19vw,340px)/.8 "Manrope",sans-serif; letter-spacing:-18px; text-align:right; -webkit-text-stroke:1px color-mix(in srgb,var(--accent) 34%,transparent); transform:scale(.88) rotate(-4deg); transform-origin:center; transition:opacity .28s ease,transform .45s cubic-bezier(.2,.8,.2,1),-webkit-text-stroke-color .28s ease; white-space:nowrap; }
+.question-stage.has-active .stage-mark { opacity:.17; transform:scale(1) rotate(-2deg); }
 
 /* ============================================================
-   03. ALL-SITES DRAWER
+   03. INTRODUCTION
+   ============================================================ */
+.stage-intro { position:absolute; z-index:8; top:105px; left:max(32px,calc((100vw - 1380px)/2)); pointer-events:none; }
+.stage-intro > p { display:flex; align-items:center; gap:10px; margin:0 0 13px; color:rgba(255,255,255,.46); font-size:9px; font-weight:800; letter-spacing:1.7px; text-transform:uppercase; }
+.stage-intro > p span { width:7px; height:7px; background:var(--lime); border-radius:50%; box-shadow:0 0 0 6px rgba(200,241,105,.075),0 0 20px rgba(200,241,105,.36); }
+.stage-intro h1 { margin:0; font:700 clamp(31px,3vw,48px)/1 "Manrope",sans-serif; letter-spacing:-2.4px; }
+.stage-intro-row { display:flex; gap:17px; margin-top:12px; color:rgba(255,255,255,.43); font-size:11px; }
+.stage-intro-row span + span:before { margin-right:17px; content:"/"; color:rgba(255,255,255,.18); }
+
+/* ============================================================
+   04. QUESTION HYPERLINK FIELD
+   ============================================================ */
+.question-field { position:absolute; z-index:10; inset:0; transform:translate3d(var(--field-x,0),var(--field-y,0),0); transition:transform .12s linear; }
+.question-link { --mag-x:0px; --mag-y:0px; position:absolute; top:var(--y); left:var(--x); display:grid; width:var(--width); grid-template-columns:25px minmax(0,1fr) 25px; align-items:start; gap:9px; color:rgba(255,255,255,.68); opacity:0; translate:0 15px; transform:translate3d(var(--mag-x),var(--mag-y),0); transition:opacity .25s ease,filter .25s ease,color .2s ease,transform .16s ease; animation:question-arrive .72s cubic-bezier(.2,.8,.2,1) var(--delay) forwards; }
+.question-number { padding-top:5px; color:color-mix(in srgb,var(--accent) 72%,white); font:800 8px "Manrope",sans-serif; letter-spacing:1px; }
+.question-text { display:block; font:650 var(--size)/.98 "Manrope",sans-serif; letter-spacing:calc(var(--size) * -.045); text-wrap:balance; transform-origin:left center; transition:transform .28s cubic-bezier(.2,.8,.2,1),text-shadow .2s ease; }
+.question-arrow { display:grid; width:23px; height:23px; margin-top:3px; color:#101116; background:var(--accent); border-radius:50%; opacity:0; place-items:center; font-size:11px; transform:scale(.5) rotate(-35deg); transition:opacity .18s ease,transform .25s cubic-bezier(.2,.8,.2,1),background .2s ease; }
+.question-link:hover,.question-link:focus-visible,.question-link.is-active { z-index:12; color:white; outline:none; opacity:1!important; filter:none!important; }
+.question-link:hover .question-text,.question-link:focus-visible .question-text,.question-link.is-active .question-text { transform:scale(1.045); text-shadow:0 0 34px color-mix(in srgb,var(--accent) 28%,transparent); }
+.question-link:hover .question-arrow,.question-link:focus-visible .question-arrow,.question-link.is-active .question-arrow { opacity:1; transform:scale(1) rotate(0); }
+.question-link:focus-visible:after { position:absolute; inset:-12px; content:""; border:1px solid color-mix(in srgb,var(--accent) 60%,transparent); border-radius:12px; }
+.question-stage.has-active .question-link:not(.is-active):not(.is-related) { opacity:.11!important; filter:blur(.35px); }
+.question-stage.has-active .question-link.is-related { opacity:.42!important; }
+.question-link.is-filtered { opacity:.035!important; pointer-events:none; filter:blur(1px); }
+@keyframes question-arrive { to { opacity:.68; translate:0 0; } }
+
+/* ============================================================
+   05. RELATIONSHIP LINES
+   ============================================================ */
+.question-lines { position:absolute; z-index:2; inset:0; width:100%; height:100%; overflow:visible; pointer-events:none; }
+.question-lines line { stroke:rgba(255,255,255,.09); stroke-width:1; vector-effect:non-scaling-stroke; transition:stroke .22s ease,opacity .22s ease,stroke-width .22s ease; }
+.question-lines line.is-active { stroke:color-mix(in srgb,var(--accent) 54%,transparent); stroke-width:1.4; }
+.question-lines line.is-filtered { opacity:.04; }
+
+/* ============================================================
+   06. MINIMAL PROJECT READOUT
+   ============================================================ */
+.project-readout { position:absolute; z-index:20; right:max(32px,calc((100vw - 1380px)/2)); bottom:25px; left:max(32px,calc((100vw - 1380px)/2)); display:grid; min-height:54px; padding-top:15px; grid-template-columns:45px minmax(200px,.75fr) minmax(300px,1.3fr) auto; align-items:start; gap:20px; border-top:1px solid rgba(255,255,255,.13); }
+.readout-index { color:var(--accent); font:800 9px "Manrope",sans-serif; letter-spacing:1.2px; transition:color .2s ease; }
+.project-readout strong { overflow:hidden; font:700 12px "Manrope",sans-serif; text-overflow:ellipsis; white-space:nowrap; }
+.project-readout p { margin:0; color:rgba(255,255,255,.43); font-size:11px; line-height:1.45; }
+.readout-action { color:rgba(255,255,255,.38); font-size:9px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
+.question-stage.has-active .readout-action { color:var(--accent); }
+.stage-tools { display:none; }
+
+/* ============================================================
+   07. ALL-PROJECTS DRAWER
    ============================================================ */
 body.directory-open { overflow:hidden; }
 .directory-drawer-layer { position:fixed; z-index:100; inset:0; pointer-events:none; }
-.directory-scrim { position:absolute; inset:0; width:100%; height:100%; padding:0; background:rgba(10,11,15,.46); border:0; opacity:0; cursor:pointer; transition:opacity .24s ease; }
-.directory-drawer { position:absolute; top:0; right:0; display:flex; width:min(460px,100%); height:100%; padding:34px 34px 24px; flex-direction:column; color:#171820; background:#f6f4ef; box-shadow:-25px 0 70px rgba(10,11,15,.22); transform:translateX(102%); transition:transform .3s cubic-bezier(.22,.7,.24,1); }
+.directory-scrim { position:absolute; inset:0; width:100%; height:100%; padding:0; background:rgba(5,6,9,.62); border:0; opacity:0; cursor:pointer; backdrop-filter:blur(4px); transition:opacity .24s ease; }
+.directory-drawer { position:absolute; top:0; right:0; display:flex; width:min(500px,100%); height:100%; padding:36px 36px 25px; flex-direction:column; color:#171820; background:#f6f4ef; box-shadow:-25px 0 80px rgba(0,0,0,.28); transform:translateX(102%); transition:transform .34s cubic-bezier(.22,.7,.24,1); }
 body.directory-open .directory-drawer-layer { pointer-events:auto; }
 body.directory-open .directory-scrim { opacity:1; }
 body.directory-open .directory-drawer { transform:translateX(0); }
 .directory-drawer-header { display:flex; align-items:flex-start; justify-content:space-between; gap:24px; }
-.directory-drawer-header p { margin:0 0 8px; color:#7657db; font-size:10px; font-weight:800; letter-spacing:1.4px; text-transform:uppercase; }
+.directory-drawer-header p { margin:0 0 8px; color:#7657db; font-size:9px; font-weight:800; letter-spacing:1.4px; text-transform:uppercase; }
 .directory-drawer-header h2 { margin:0; font:800 42px/1 "Manrope",sans-serif; letter-spacing:-2px; }
 .directory-close { display:grid; width:38px; height:38px; padding:0; color:#171820; background:transparent; border:1px solid #d2cec4; border-radius:50%; place-items:center; font-size:24px; line-height:1; cursor:pointer; }
-.directory-search-label { margin-top:31px; color:#6e7078; font-size:10px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
+.directory-search-label { margin-top:31px; color:#6e7078; font-size:9px; font-weight:800; letter-spacing:1px; text-transform:uppercase; }
 .directory-search { width:100%; margin-top:8px; padding:13px 0; color:#171820; background:transparent; border:0; border-bottom:1px solid #cfcac0; border-radius:0; outline:none; font:600 15px "DM Sans",sans-serif; }
 .directory-search:focus { border-bottom-color:#7657db; }
 .directory-list { flex:1; margin-top:18px; overflow:auto; border-top:1px solid #ded9cf; }
-.directory-drawer .directory-card { display:grid; min-height:0; padding:17px 2px; grid-template-columns:1fr auto; gap:4px 16px; background:transparent; border:0; border-bottom:1px solid #ded9cf; border-radius:0; transform:none; }
-.directory-drawer .directory-card:hover { border-color:#b8b0ce; transform:none; }
-.directory-drawer .directory-card span { grid-column:1; color:#7657db; font-size:8px; letter-spacing:.9px; }
+.directory-drawer .directory-card { display:grid; min-height:0; padding:17px 2px; grid-template-columns:1fr auto; gap:4px 16px; background:transparent; border:0; border-bottom:1px solid #ded9cf; border-radius:0; }
+.directory-drawer .directory-card span { grid-column:1; color:#7657db; font-size:8px; font-weight:800; letter-spacing:.9px; text-transform:uppercase; }
 .directory-drawer .directory-card h3 { grid-column:1; margin:1px 0 0; font:800 17px/1.2 "Manrope",sans-serif; letter-spacing:-.35px; }
 .directory-drawer .directory-card p { grid-column:1; margin:2px 0 0; color:#6b6d75; font-size:11px; line-height:1.4; }
 .directory-drawer .directory-card b { grid-column:2; grid-row:1/4; align-self:center; margin:0; padding:0; font-size:0; }
 .directory-drawer .directory-card b:after { content:"↗"; font-size:16px; }
-.directory-drawer .directory-loading,.directory-drawer .directory-error { padding:20px 0; color:#6b6d75; background:transparent; border:0; border-radius:0; }
+.directory-drawer .directory-loading,.directory-drawer .directory-error { padding:20px 0; color:#6b6d75; background:transparent; border:0; }
 .directory-drawer-note { margin:17px 0 0; color:#85868c; font-size:10px; line-height:1.45; }
 
 /* ============================================================
-   04. TABLET AND MOBILE
+   08. MOBILE — THE QUESTIONS BECOME A CLEAN LINKED INDEX
    ============================================================ */
-@media(max-width:980px) {
-  .project-universe:after { background:linear-gradient(180deg,rgba(13,14,19,.98) 0%,rgba(13,14,19,.9) 43%,rgba(13,14,19,.16) 70%,rgba(13,14,19,.42) 100%); }
-  .universe-shell { min-height:860px; grid-template-columns:1fr; align-items:start; gap:34px; padding-top:62px; }
-  .universe-copy { max-width:700px; }
-  .universe-panel { width:min(100%,390px); align-self:end; justify-self:end; }
-}
-
-@media(max-width:560px) {
-  .project-universe { min-height:860px; }
-  .universe-grid { background-size:46px 46px; }
-  .universe-shell { min-height:860px; gap:24px; padding-block:42px 30px; }
-  .universe-kicker { margin-bottom:20px; font-size:9px; letter-spacing:1.15px; }
-  .universe-copy h1 { font-size:50px; line-height:.94; letter-spacing:-3.6px; }
-  .universe-copy h1 em { font-size:.86em; white-space:normal; -webkit-text-stroke-width:1px; }
-  .universe-intro { max-width:95%; margin-top:22px; font-size:14px; line-height:1.55; }
-  .universe-actions { align-items:flex-start; flex-direction:column; gap:15px; margin-top:25px; }
-  .universe-button { padding:12px 15px 12px 17px; }
-  .universe-panel { width:100%; padding:18px; border-radius:15px; }
-  .universe-panel h2 { margin-top:17px; font-size:20px; }
-  .universe-panel > p { min-height:52px; }
-  .universe-panel-actions { gap:10px; }
+@media(max-width:760px) {
+  body { overflow:auto; }
+  .shell { width:calc(100% - 30px); }
+  .home-header { position:absolute; height:70px; }
+  .wordmark small { display:none; }
+  .home-header nav { gap:15px; }
+  .home-header .nav-filter,.home-header .nav-archive { display:none; }
+  .home-header .nav-directory { padding:8px 11px; }
+  .question-stage { min-height:100svh; padding:96px 16px 35px; overflow:visible; }
+  .stage-grid { display:none; }
+  .stage-mark { display:none; }
+  .stage-intro { position:relative; top:auto; left:auto; margin:0 0 42px; }
+  .stage-intro h1 { font-size:39px; letter-spacing:-2px; }
+  .stage-intro-row { flex-direction:column; gap:3px; }
+  .stage-intro-row span + span:before { display:none; }
+  .question-field { position:relative; display:flex; inset:auto; flex-direction:column; transform:none!important; }
+  .question-link { position:relative; top:auto; left:auto; width:100%; padding:20px 0; grid-template-columns:24px minmax(0,1fr) 28px; border-top:1px solid rgba(255,255,255,.12); transform:none!important; }
+  .question-link:last-child { border-bottom:1px solid rgba(255,255,255,.12); }
+  .question-text { font-size:clamp(27px,8vw,38px); letter-spacing:-1.7px; }
+  .question-arrow { opacity:.45; transform:scale(.8); }
+  .question-stage.has-active .question-link:not(.is-active):not(.is-related),.question-stage.has-active .question-link.is-related { opacity:.68!important; filter:none; }
+  .question-link.is-filtered { display:none; }
+  .question-lines,.project-readout { display:none; }
+  .stage-tools { display:flex; margin-top:28px; align-items:center; justify-content:space-between; gap:16px; }
+  .stage-tools button,.stage-tools a { padding:0; color:rgba(255,255,255,.58); background:none; border:0; font-size:11px; font-weight:700; }
+  .stage-tools button span { margin-left:8px; color:rgba(255,255,255,.27); font-size:9px; }
   .directory-drawer { padding:26px 22px 20px; }
   .directory-drawer-header h2 { font-size:36px; }
 }
 
 /* ============================================================
-   05. ACCESSIBILITY AND LOW-MOTION MODE
+   09. ACCESSIBILITY AND REDUCED MOTION
    ============================================================ */
 @media(prefers-reduced-motion:reduce) {
-  .universe-button,.universe-accessible-list button,.directory-scrim,.directory-drawer { transition:none; }
+  .question-field,.question-link,.question-text,.question-arrow,.stage-mark,.directory-scrim,.directory-drawer { transition:none!important; animation:none!important; }
+  .question-link { opacity:.68; translate:0 0; }
 }

--- a/home-universe.js
+++ b/home-universe.js
@@ -1,246 +1,229 @@
 /* ============================================================
-   00. PROJECT DATA
+   00. QUESTION-FIELD CONFIGURATION
+   The connections are conceptual relationships between projects.
    ============================================================ */
-const universeProjects = [
-  { title:"Population Health: The Whole System", short:"Whole system", type:"Interactive systems map", description:"Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.", url:"https://pelld.github.io/population-health-system-explorer/", colour:"#71e2bd", x:.66, y:.22, radius:28 },
-  { title:"Population Health: Size of the Prize", short:"Size of the prize", type:"Decision support prototype", description:"Explore how interventions affect the whole person and compare health, financial and societal returns.", url:"https://pelld.github.io/population-health-size-of-prize/", colour:"#d9f279", x:.9, y:.31, radius:25 },
-  { title:"Population Health Atlas", short:"Health atlas", type:"Geographic analysis", description:"Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.", url:"https://pelld.github.io/population-health-atlas/", colour:"#78b9ef", x:.76, y:.52, radius:27 },
-  { title:"P-Value Explorer", short:"P-value explorer", type:"PubMed evidence explorer", description:"Search abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.", url:"https://pelld.github.io/p-value-explorer/", colour:"#aa8df4", x:.94, y:.61, radius:23 },
-  { title:"Where Is the Art?", short:"Where is the art?", type:"Interactive art map", description:"Search by artist or place to discover where artworks are held and what can be seen nearby.", url:"https://pelld.github.io/where-is-the-art/", colour:"#ff9775", x:.62, y:.65, radius:31 },
-  { title:"Quiz Duel Stars", short:"Quiz duel", type:"Two-device game", description:"Fast head-to-head trivia played together from different phones and different locations.", url:"https://pelld.github.io/quiz-duel-stars/", colour:"#f3d864", x:.49, y:.46, radius:24 },
-  { title:"Amelia in Nepal", short:"Amelia in Nepal", type:"Personal adventure", description:"A personalised journey through the mountains, built as a playable web adventure.", url:"https://pelld.github.io/amelia-nepal-game/", colour:"#80d9c8", x:.48, y:.2, radius:22 },
-  { title:"Hunter's Dirt Bike Adventure", short:"Dirt bike adventure", type:"Action game", description:"Ride, jump and perform tricks across a game-world inspired by the North Pennines.", url:"https://pelld.github.io/hunter-dirt-bike-adventure/", colour:"#eeb06f", x:.4, y:.67, radius:25 },
-  { title:"Animal Dash", short:"Animal dash", type:"Arcade game", description:"A bright and simple action game designed for younger players and quick bursts of play.", url:"https://pelld.github.io/animal-dash/", colour:"#ef8db3", x:.31, y:.35, radius:21 }
-];
-
-const universeConnections = [[0,1],[0,2],[0,4],[0,6],[1,2],[1,3],[2,3],[2,4],[4,6],[5,6],[5,7],[5,8],[7,8]];
+const QUESTION_CONNECTIONS = [[0,1],[0,2],[0,3],[0,5],[1,2],[1,3],[2,5],[3,5],[4,5],[4,7],[6,7]];
 
 /* ============================================================
-   01. INITIALISE THE CANVAS AND INTERFACE
+   01. INITIALISE THE INTERACTIVE FIELD
    ============================================================ */
 (() => {
-  const canvas = document.getElementById("universe-canvas");
-  const universe = document.querySelector(".project-universe");
-  if (!canvas || !universe) return;
-
-  const context = canvas.getContext("2d");
-  const panelIndex = document.getElementById("universe-panel-index");
-  const panelType = document.getElementById("universe-panel-type");
-  const panelTitle = document.getElementById("universe-panel-title");
-  const panelDescription = document.getElementById("universe-panel-description");
-  const panelLink = document.getElementById("universe-panel-link");
-  const accessibleButtons = [...document.querySelectorAll(".universe-accessible-list button")];
+  const stage = document.getElementById("question-stage");
+  const field = document.getElementById("question-field");
+  const svg = document.getElementById("question-lines");
+  const lineGroup = document.getElementById("question-line-group");
+  const links = [...document.querySelectorAll(".question-link")];
+  const filterButtons = [...document.querySelectorAll("[data-project-filter]")];
+  const mark = document.getElementById("stage-mark");
+  const readoutIndex = document.getElementById("readout-index");
+  const readoutTitle = document.getElementById("readout-title");
+  const readoutDescription = document.getElementById("readout-description");
+  const readoutAction = document.getElementById("readout-action");
   const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-  let width = 0;
-  let height = 0;
-  let pixelRatio = 1;
-  let selectedProject = 0;
-  let hoverProject = -1;
-  let pointer = { x:-1000, y:-1000, active:false };
-  let scrollProgress = 0;
-  let animationFrame = 0;
-  const startTime = performance.now();
+  if (!stage || !field || !svg || !lineGroup || links.length === 0) return;
 
-  const nodes = universeProjects.map((project, index) => ({ ...project, index, px:0, py:0, displayX:0, displayY:0 }));
+  const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+  const lineElements = [];
+  let activeLink = null;
+  let lineFrame = 0;
+  let fieldX = 0;
+  let fieldY = 0;
 
   /* ============================================================
-     02. RESIZE AND POSITION NODES
-     Desktop nodes are deliberately constrained to the right so
-     the graphic supports the headline rather than crossing it.
+     02. CREATE AND POSITION RELATIONSHIP LINES
      ============================================================ */
-  const resize = () => {
-    const bounds = universe.getBoundingClientRect();
-    width = Math.max(320, bounds.width);
-    height = Math.max(560, bounds.height);
-    pixelRatio = Math.min(window.devicePixelRatio || 1, 1.75);
-    canvas.width = Math.round(width * pixelRatio);
-    canvas.height = Math.round(height * pixelRatio);
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
-
-    nodes.forEach(node => {
-      const mobile = width < 720;
-      node.px = mobile ? width * (.1 + node.x * .8) : width * (.54 + node.x * .43);
-      node.py = mobile ? height * (.4 + node.y * .45) : height * (.08 + node.y * .76);
-      if (!node.displayX) { node.displayX = node.px; node.displayY = node.py; }
-    });
-  };
-
-  /* ============================================================
-     03. PROJECT SELECTION
-     ============================================================ */
-  const selectProject = (index, pin = false) => {
-    const project = universeProjects[index];
-    if (!project) return;
-    if (pin) selectedProject = index;
-    panelIndex.textContent = `${String(index + 1).padStart(2, "0")} / ${String(universeProjects.length).padStart(2, "0")}`;
-    panelType.textContent = project.type;
-    panelTitle.textContent = project.title;
-    panelDescription.textContent = project.description;
-    panelLink.href = project.url;
-    accessibleButtons.forEach((button, buttonIndex) => button.setAttribute("aria-pressed", buttonIndex === index ? "true" : "false"));
-  };
-
-  accessibleButtons.forEach(button => button.addEventListener("click", () => selectProject(Number(button.dataset.project), true)));
-
-  /* ============================================================
-     04. POINTER, TOUCH AND SCROLL INPUT
-     ============================================================ */
-  const setPointer = event => {
-    const bounds = canvas.getBoundingClientRect();
-    pointer.x = event.clientX - bounds.left;
-    pointer.y = event.clientY - bounds.top;
-    pointer.active = true;
-  };
-
-  canvas.addEventListener("pointermove", setPointer);
-  canvas.addEventListener("pointerleave", () => { pointer.active = false; hoverProject = -1; selectProject(selectedProject); });
-  canvas.addEventListener("pointerdown", event => {
-    setPointer(event);
-    if (hoverProject >= 0) selectProject(hoverProject, true);
+  QUESTION_CONNECTIONS.forEach(([from, to]) => {
+    const line = document.createElementNS(SVG_NAMESPACE, "line");
+    line.dataset.from = String(from);
+    line.dataset.to = String(to);
+    lineGroup.append(line);
+    lineElements.push(line);
   });
 
-  window.addEventListener("scroll", () => {
-    const bounds = universe.getBoundingClientRect();
-    scrollProgress = Math.max(0, Math.min(1, -bounds.top / Math.max(1, bounds.height)));
-  }, { passive:true });
+  const updateLines = () => {
+    lineFrame = 0;
+    const stageBounds = stage.getBoundingClientRect();
 
-  window.addEventListener("resize", resize);
+    lineElements.forEach(line => {
+      const from = links[Number(line.dataset.from)];
+      const to = links[Number(line.dataset.to)];
+      if (!from || !to) return;
 
-  /* ============================================================
-     05. DRAW HELPERS
-     ============================================================ */
-  const hexToRgba = (hex, alpha) => {
-    const value = parseInt(hex.slice(1), 16);
-    return `rgba(${value >> 16}, ${(value >> 8) & 255}, ${value & 255}, ${alpha})`;
+      const fromBounds = from.getBoundingClientRect();
+      const toBounds = to.getBoundingClientRect();
+      line.setAttribute("x1", String(fromBounds.left + fromBounds.width / 2 - stageBounds.left - fieldX));
+      line.setAttribute("y1", String(fromBounds.top + fromBounds.height / 2 - stageBounds.top - fieldY));
+      line.setAttribute("x2", String(toBounds.left + toBounds.width / 2 - stageBounds.left - fieldX));
+      line.setAttribute("y2", String(toBounds.top + toBounds.height / 2 - stageBounds.top - fieldY));
+    });
   };
 
-  const roundedRect = (x, y, w, h, radius) => {
-    const r = Math.min(radius, w / 2, h / 2);
-    context.beginPath();
-    context.moveTo(x + r, y);
-    context.arcTo(x + w, y, x + w, y + h, r);
-    context.arcTo(x + w, y + h, x, y + h, r);
-    context.arcTo(x, y + h, x, y, r);
-    context.arcTo(x, y, x + w, y, r);
-    context.closePath();
+  const scheduleLineUpdate = () => {
+    if (lineFrame) return;
+    lineFrame = requestAnimationFrame(updateLines);
   };
 
   /* ============================================================
-     06. ANIMATION LOOP
+     03. PROJECT ACTIVATION AND READOUT
      ============================================================ */
-  const draw = now => {
-    const elapsed = (now - startTime) / 1000;
-    context.clearRect(0, 0, width, height);
-
-    hoverProject = -1;
-    let closestDistance = Number.POSITIVE_INFINITY;
-
-    nodes.forEach(node => {
-      const driftX = prefersReducedMotion ? 0 : Math.sin(elapsed * .42 + node.index * 1.9) * 6;
-      const driftY = prefersReducedMotion ? 0 : Math.cos(elapsed * .38 + node.index * 1.4) * 5;
-      let targetX = node.px + driftX - scrollProgress * (node.index % 2 ? 14 : -10);
-      let targetY = node.py + driftY - scrollProgress * (14 + node.index);
-
-      if (pointer.active) {
-        const dx = targetX - pointer.x;
-        const dy = targetY - pointer.y;
-        const distance = Math.hypot(dx, dy);
-        if (distance < 150 && distance > 0) {
-          const force = (150 - distance) / 150;
-          targetX += (dx / distance) * force * 20;
-          targetY += (dy / distance) * force * 20;
-        }
-      }
-
-      node.displayX += (targetX - node.displayX) * (prefersReducedMotion ? 1 : .06);
-      node.displayY += (targetY - node.displayY) * (prefersReducedMotion ? 1 : .06);
-
-      if (pointer.active) {
-        const distance = Math.hypot(node.displayX - pointer.x, node.displayY - pointer.y);
-        if (distance < node.radius + 28 && distance < closestDistance) { closestDistance = distance; hoverProject = node.index; }
-      }
+  const relatedIndexes = index => {
+    const related = new Set();
+    QUESTION_CONNECTIONS.forEach(([from, to]) => {
+      if (from === index) related.add(to);
+      if (to === index) related.add(from);
     });
-
-    canvas.style.cursor = hoverProject >= 0 ? "pointer" : "default";
-    if (hoverProject >= 0) selectProject(hoverProject);
-
-    /* Draw restrained connections behind the nodes. */
-    universeConnections.forEach(([fromIndex, toIndex]) => {
-      const from = nodes[fromIndex];
-      const to = nodes[toIndex];
-      const highlighted = [fromIndex, toIndex].includes(hoverProject >= 0 ? hoverProject : selectedProject);
-      const gradient = context.createLinearGradient(from.displayX, from.displayY, to.displayX, to.displayY);
-      gradient.addColorStop(0, hexToRgba(from.colour, highlighted ? .42 : .1));
-      gradient.addColorStop(1, hexToRgba(to.colour, highlighted ? .42 : .1));
-      context.strokeStyle = gradient;
-      context.lineWidth = highlighted ? 1.3 : .65;
-      context.beginPath();
-      context.moveTo(from.displayX, from.displayY);
-      context.lineTo(to.displayX, to.displayY);
-      context.stroke();
-    });
-
-    /* Only the active node receives a label. */
-    nodes.forEach(node => {
-      const activeIndex = hoverProject >= 0 ? hoverProject : selectedProject;
-      const active = node.index === activeIndex;
-      const radius = node.radius * (active ? 1.16 : 1);
-
-      context.strokeStyle = hexToRgba(node.colour, active ? .46 : .09);
-      context.lineWidth = 1;
-      context.beginPath();
-      context.arc(node.displayX, node.displayY, radius + (active ? 16 : 9), 0, Math.PI * 2);
-      context.stroke();
-
-      const glow = context.createRadialGradient(node.displayX, node.displayY, 2, node.displayX, node.displayY, radius * 2.15);
-      glow.addColorStop(0, hexToRgba(node.colour, active ? .52 : .24));
-      glow.addColorStop(1, hexToRgba(node.colour, 0));
-      context.fillStyle = glow;
-      context.beginPath();
-      context.arc(node.displayX, node.displayY, radius * 2.15, 0, Math.PI * 2);
-      context.fill();
-
-      context.fillStyle = node.colour;
-      context.beginPath();
-      context.arc(node.displayX, node.displayY, radius, 0, Math.PI * 2);
-      context.fill();
-
-      context.fillStyle = "rgba(12,13,19,.9)";
-      context.beginPath();
-      context.arc(node.displayX, node.displayY, Math.max(7, radius - 7), 0, Math.PI * 2);
-      context.fill();
-
-      context.fillStyle = node.colour;
-      context.beginPath();
-      context.arc(node.displayX, node.displayY, active ? 6 : 4, 0, Math.PI * 2);
-      context.fill();
-
-      if (active) {
-        context.font = `700 ${width < 720 ? 10 : 11}px "DM Sans", sans-serif`;
-        const textWidth = context.measureText(node.short).width;
-        const labelWidth = textWidth + 20;
-        const labelX = node.displayX - labelWidth / 2;
-        const labelY = node.displayY + radius + 14;
-        roundedRect(labelX, labelY, labelWidth, 25, 12.5);
-        context.fillStyle = "rgba(247,247,242,.94)";
-        context.fill();
-        context.fillStyle = "#171820";
-        context.textAlign = "center";
-        context.textBaseline = "middle";
-        context.fillText(node.short, node.displayX, labelY + 12.5);
-      }
-    });
-
-    if (!prefersReducedMotion) animationFrame = requestAnimationFrame(draw);
+    return related;
   };
 
-  resize();
-  selectProject(0, true);
-  if (prefersReducedMotion) draw(performance.now());
-  else animationFrame = requestAnimationFrame(draw);
+  const activate = link => {
+    if (!link || link.classList.contains("is-filtered")) return;
+    activeLink = link;
+    const index = Number(link.dataset.index);
+    const related = relatedIndexes(index);
+    const colour = link.dataset.colour || "#c8f169";
 
-  window.addEventListener("pagehide", () => cancelAnimationFrame(animationFrame), { once:true });
+    stage.classList.add("has-active");
+    stage.style.setProperty("--accent", colour);
+    links.forEach(candidate => {
+      const candidateIndex = Number(candidate.dataset.index);
+      candidate.classList.toggle("is-active", candidate === link);
+      candidate.classList.toggle("is-related", candidate !== link && related.has(candidateIndex));
+    });
+
+    lineElements.forEach(line => {
+      const from = Number(line.dataset.from);
+      const to = Number(line.dataset.to);
+      line.classList.toggle("is-active", from === index || to === index);
+    });
+
+    if (mark) {
+      mark.textContent = link.dataset.mark || "?";
+      if (!prefersReducedMotion && typeof mark.animate === "function") {
+        mark.animate([{ opacity:0, transform:"scale(.9) rotate(-4deg)" },{ opacity:.17, transform:"scale(1) rotate(-2deg)" }], { duration:340, easing:"cubic-bezier(.2,.8,.2,1)" });
+      }
+    }
+
+    if (readoutIndex) readoutIndex.textContent = String(index + 1).padStart(2, "0");
+    if (readoutTitle) readoutTitle.textContent = link.dataset.projectTitle || link.textContent.trim();
+    if (readoutDescription) readoutDescription.textContent = link.dataset.description || "Open this project.";
+    if (readoutAction) readoutAction.textContent = "Click to open ↗";
+  };
+
+  const reset = () => {
+    activeLink = null;
+    stage.classList.remove("has-active");
+    stage.style.setProperty("--accent", "#c8f169");
+    links.forEach(link => link.classList.remove("is-active","is-related"));
+    lineElements.forEach(line => line.classList.remove("is-active"));
+    if (mark) mark.textContent = "?";
+    if (readoutIndex) readoutIndex.textContent = "00";
+    if (readoutTitle) readoutTitle.textContent = "Move through the questions";
+    if (readoutDescription) readoutDescription.textContent = "The links react, reveal their relationships and open the project directly.";
+    if (readoutAction) readoutAction.textContent = "Select a question";
+  };
+
+  links.forEach(link => {
+    link.addEventListener("pointerenter", () => activate(link));
+    link.addEventListener("focus", () => activate(link));
+    link.addEventListener("blur", () => {
+      window.setTimeout(() => { if (!field.contains(document.activeElement)) reset(); }, 0);
+    });
+  });
+
+  field.addEventListener("pointerleave", reset);
+
+  /* ============================================================
+     04. POINTER LIGHT, PARALLAX AND MAGNETIC LINKS
+     ============================================================ */
+  const clearMagnetism = () => {
+    links.forEach(link => {
+      link.style.setProperty("--mag-x", "0px");
+      link.style.setProperty("--mag-y", "0px");
+    });
+  };
+
+  stage.addEventListener("pointermove", event => {
+    const bounds = stage.getBoundingClientRect();
+    const localX = event.clientX - bounds.left;
+    const localY = event.clientY - bounds.top;
+    stage.style.setProperty("--mx", `${localX}px`);
+    stage.style.setProperty("--my", `${localY}px`);
+
+    if (prefersReducedMotion || window.innerWidth <= 760) return;
+
+    fieldX = ((localX / bounds.width) - .5) * -10;
+    fieldY = ((localY / bounds.height) - .5) * -7;
+    field.style.setProperty("--field-x", `${fieldX}px`);
+    field.style.setProperty("--field-y", `${fieldY}px`);
+    svg.style.transform = `translate3d(${fieldX}px,${fieldY}px,0)`;
+
+    links.forEach(link => {
+      const linkBounds = link.getBoundingClientRect();
+      const centreX = linkBounds.left + linkBounds.width / 2;
+      const centreY = linkBounds.top + linkBounds.height / 2;
+      const deltaX = event.clientX - centreX;
+      const deltaY = event.clientY - centreY;
+      const distance = Math.hypot(deltaX, deltaY);
+      const influence = Math.max(0, 1 - distance / 190);
+      link.style.setProperty("--mag-x", `${deltaX * influence * .055}px`);
+      link.style.setProperty("--mag-y", `${deltaY * influence * .055}px`);
+    });
+
+    scheduleLineUpdate();
+  });
+
+  stage.addEventListener("pointerleave", () => {
+    fieldX = 0;
+    fieldY = 0;
+    field.style.setProperty("--field-x", "0px");
+    field.style.setProperty("--field-y", "0px");
+    svg.style.transform = "translate3d(0,0,0)";
+    clearMagnetism();
+    scheduleLineUpdate();
+  });
+
+  /* ============================================================
+     05. CATEGORY FOCUS MODES
+     ============================================================ */
+  const applyFilter = filter => {
+    filterButtons.forEach(button => button.setAttribute("aria-pressed", button.dataset.projectFilter === filter ? "true" : "false"));
+    links.forEach(link => link.classList.toggle("is-filtered", filter !== "all" && link.dataset.group !== filter));
+    lineElements.forEach(line => {
+      const from = links[Number(line.dataset.from)];
+      const to = links[Number(line.dataset.to)];
+      line.classList.toggle("is-filtered", from?.classList.contains("is-filtered") || to?.classList.contains("is-filtered"));
+    });
+    reset();
+  };
+
+  filterButtons.forEach(button => button.addEventListener("click", () => applyFilter(button.dataset.projectFilter || "all")));
+
+  /* ============================================================
+     06. KEYBOARD SHORTCUTS
+     ============================================================ */
+  document.addEventListener("keydown", event => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      document.querySelector("[data-directory-open]")?.click();
+      return;
+    }
+
+    if (!["ArrowRight","ArrowDown","ArrowLeft","ArrowUp"].includes(event.key) || !activeLink) return;
+    event.preventDefault();
+    const visibleLinks = links.filter(link => !link.classList.contains("is-filtered"));
+    const currentIndex = visibleLinks.indexOf(activeLink);
+    const direction = ["ArrowRight","ArrowDown"].includes(event.key) ? 1 : -1;
+    visibleLinks[(currentIndex + direction + visibleLinks.length) % visibleLinks.length]?.focus();
+  });
+
+  /* ============================================================
+     07. RESIZE AND FONT-LOAD SYNCHRONISATION
+     ============================================================ */
+  const resizeObserver = new ResizeObserver(scheduleLineUpdate);
+  resizeObserver.observe(stage);
+  links.forEach(link => resizeObserver.observe(link));
+  window.addEventListener("resize", scheduleLineUpdate);
+  document.fonts?.ready.then(scheduleLineUpdate);
+  scheduleLineUpdate();
 })();

--- a/index.html
+++ b/index.html
@@ -3,117 +3,97 @@ layout: home
 title: Projects
 ---
 
-<main>
-  <!-- ============================================================
-       01. LIVING PROJECT MAP
-       ============================================================ -->
-  <section class="project-universe" id="top" aria-labelledby="universe-title">
-    <canvas id="universe-canvas" aria-hidden="true"></canvas>
-    <div class="universe-grid" aria-hidden="true"></div>
-    <div class="universe-glow universe-glow-one" aria-hidden="true"></div>
-    <div class="universe-glow universe-glow-two" aria-hidden="true"></div>
+<!-- ============================================================
+     01. INTERACTIVE QUESTION FIELD
+     Every visible question is a real hyperlink. JavaScript adds
+     motion, relationships and previews but is not needed to navigate.
+     ============================================================ -->
+<main class="question-stage" id="question-stage">
+  <div class="stage-light" aria-hidden="true"></div>
+  <div class="stage-grid" aria-hidden="true"></div>
+  <div class="stage-grain" aria-hidden="true"></div>
+  <div class="stage-mark" id="stage-mark" aria-hidden="true">?</div>
 
-    <div class="universe-shell shell">
-      <div class="universe-copy">
-        <p class="universe-kicker"><span></span> Independent web projects</p>
-        <h1 id="universe-title">Things built to<br><em>understand things.</em></h1>
-        <p class="universe-intro">Maps, games, evidence tools and experiments. Each starts with a question and follows it further than a normal webpage usually would.</p>
-        <div class="universe-actions"><a class="universe-button" href="#projects">Explore the collection <span>↓</span></a><button type="button" class="universe-text-link" data-directory-open>All projects <span>↗</span></button></div>
-      </div>
+  <svg class="question-lines" id="question-lines" aria-hidden="true">
+    <g id="question-line-group"></g>
+  </svg>
 
-      <aside class="universe-panel" id="universe-panel" aria-live="polite">
-        <div class="universe-panel-top"><span class="universe-panel-index" id="universe-panel-index">01 / 09</span><span class="universe-panel-type" id="universe-panel-type">Interactive systems map</span></div>
-        <h2 id="universe-panel-title">Population Health: The Whole System</h2>
-        <p id="universe-panel-description">Follow the relationships between wider determinants, prevention, treatment and recovery—and keep asking why.</p>
-        <div class="universe-panel-actions"><a id="universe-panel-link" href="https://pelld.github.io/population-health-system-explorer/">Open project <span>↗</span></a>
-          <div class="universe-accessible-list" aria-label="Select a featured project">
-            <button type="button" data-project="0">Population Health: The Whole System</button>
-            <button type="button" data-project="1">Population Health: Size of the Prize</button>
-            <button type="button" data-project="2">Population Health Atlas</button>
-            <button type="button" data-project="3">P-Value Explorer</button>
-            <button type="button" data-project="4">Where Is the Art?</button>
-            <button type="button" data-project="5">Quiz Duel Stars</button>
-            <button type="button" data-project="6">Amelia in Nepal</button>
-            <button type="button" data-project="7">Hunter's Dirt Bike Adventure</button>
-            <button type="button" data-project="8">Animal Dash</button>
-          </div>
-        </div>
-      </aside>
+  <section class="stage-intro" aria-labelledby="stage-title">
+    <p><span></span> Independent web experiments</p>
+    <h1 id="stage-title">Choose a question.</h1>
+    <div class="stage-intro-row">
+      <span>Each question is a project.</span>
+      <span>Click to open it.</span>
     </div>
   </section>
 
   <!-- ============================================================
-       02. FEATURED PROJECT
+       02. DIRECT PROJECT LINKS
+       Position, scale and colour are deliberately stored with each
+       project so this remains straightforward to edit later.
        ============================================================ -->
-  <section class="work shell" id="projects">
-    <div class="section-title"><div><p class="kicker">Featured project</p><h2>Find art anywhere.</h2></div><p>Search by artist to discover where their work is held, or start with a place to see what is nearby.</p></div>
-    <a class="feature-card" href="https://pelld.github.io/where-is-the-art/">
-      <div class="feature-copy"><span class="pill">Interactive art explorer</span><h3>Where Is the Art?</h3><p>From Rembrandt to Michelangelo: explore artworks, museums and locations on one map.</p><span class="open-link">Open the project <b>↗</b></span></div>
-      <div class="map-art" aria-hidden="true"><div class="land land-one"></div><div class="land land-two"></div><i class="pin pin-one"></i><i class="pin pin-two"></i><i class="pin pin-three"></i><div class="map-panel"><span>Artist</span><strong>Rembrandt</strong><small>Works across Europe</small></div></div>
+  <nav class="question-field" id="question-field" aria-label="Featured projects">
+    <a class="question-link" href="https://pelld.github.io/population-health-system-explorer/" data-index="0" data-group="analyse" data-colour="#72dfbd" data-mark="SYSTEM" data-project-title="Population Health: The Whole System" data-description="Explore the relationships between wider determinants, prevention, treatment and recovery." style="--x:6%;--y:28%;--size:42px;--width:390px;--delay:.04s">
+      <span class="question-number">01</span><span class="question-text">What shapes population health?</span><span class="question-arrow">↗</span>
     </a>
-  </section>
+
+    <a class="question-link" href="https://pelld.github.io/population-health-size-of-prize/" data-index="1" data-group="analyse" data-colour="#d7ef72" data-mark="£→?" data-project-title="Population Health: Size of the Prize" data-description="Compare the potential health, financial and societal impact of population health interventions." style="--x:43%;--y:23%;--size:29px;--width:350px;--delay:.1s">
+      <span class="question-number">02</span><span class="question-text">Where is the biggest opportunity?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/patient-flow-explorer/" data-index="2" data-group="analyse" data-colour="#75d4f2" data-mark="FLOW" data-project-title="Patient Flow Explorer" data-description="Follow a patient pathway and investigate where demand, delay and capacity interact." style="--x:71%;--y:31%;--size:27px;--width:285px;--delay:.16s">
+      <span class="question-number">03</span><span class="question-text">Where does the patient journey break?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/p-value-explorer/" data-index="3" data-group="analyse" data-colour="#a98cf2" data-mark="p=.05" data-project-title="P-Value Explorer" data-description="Search PubMed abstracts and inspect the distribution of reported p-values around the 0.05 threshold." style="--x:36%;--y:49%;--size:33px;--width:365px;--delay:.22s">
+      <span class="question-number">04</span><span class="question-text">What hides around p = .05?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/where-is-the-art/" data-index="4" data-group="explore" data-colour="#ff9472" data-mark="ART" data-project-title="Where Is the Art?" data-description="Search by artist or place to discover where artworks are held and what can be seen nearby." style="--x:7%;--y:67%;--size:40px;--width:390px;--delay:.28s">
+      <span class="question-number">05</span><span class="question-text">Where can you see the art?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/population-health-atlas/" data-index="5" data-group="explore" data-colour="#78b9ef" data-mark="MAP" data-project-title="Population Health Atlas" data-description="Investigate geographic patterns in recorded long-term conditions and deprivation-adjusted variation." style="--x:69%;--y:54%;--size:28px;--width:300px;--delay:.34s">
+      <span class="question-number">06</span><span class="question-text">What does place reveal?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/quiz-duel-stars/" data-index="6" data-group="play" data-colour="#f2d565" data-mark="VS" data-project-title="Quiz Duel Stars" data-description="A fast head-to-head quiz played simultaneously across two phones in different locations." style="--x:41%;--y:75%;--size:31px;--width:320px;--delay:.4s">
+      <span class="question-number">07</span><span class="question-text">Can two people play apart?</span><span class="question-arrow">↗</span>
+    </a>
+
+    <a class="question-link" href="https://pelld.github.io/amelia-nepal-game/" data-index="7" data-group="play" data-colour="#86d9c8" data-mark="↑" data-project-title="Amelia in Nepal" data-description="A personalised mountain journey built as a playable web adventure." style="--x:73%;--y:75%;--size:26px;--width:285px;--delay:.46s">
+      <span class="question-number">08</span><span class="question-text">Can a website become an adventure?</span><span class="question-arrow">↗</span>
+    </a>
+  </nav>
 
   <!-- ============================================================
-       03. HEALTH, EVIDENCE AND SYSTEMS
+       03. ACTIVE PROJECT READOUT
+       A single restrained strip replaces all project cards.
        ============================================================ -->
-  <section class="insights-section" id="insights">
-    <div class="shell">
-      <div class="section-title"><div><p class="kicker">Health, evidence and systems</p><h2>Explore the difficult questions.</h2></div><p>Interactive prototypes for investigating population health, evidence and the consequences of decisions across complex systems.</p></div>
-      <div class="insights-grid">
-        <a class="insight-card insight-system" href="https://pelld.github.io/population-health-system-explorer/">
-          <div class="insight-visual system-visual" aria-hidden="true"><span class="system-node node-a"></span><span class="system-node node-b"></span><span class="system-node node-c"></span><span class="system-node node-d"></span><i class="system-line line-a"></i><i class="system-line line-b"></i><i class="system-line line-c"></i></div>
-          <div class="insight-copy"><span class="project-status">Interactive systems map · Prototype</span><h3>Population Health: The Whole System</h3><p>Follow the relationships between wider determinants, prevention, treatment, recovery and longer lives—and keep asking why.</p><b>Explore the system ↗</b></div>
-        </a>
-        <a class="insight-card insight-prize" href="https://pelld.github.io/population-health-size-of-prize/">
-          <div class="insight-visual prize-visual" aria-hidden="true"><span class="body-head"></span><span class="body-core"></span><i class="body-point point-a"></i><i class="body-point point-b"></i><i class="body-point point-c"></i><strong>£1 → ?</strong></div>
-          <div class="insight-copy"><span class="project-status">Decision support · Illustrative prototype</span><h3>Population Health: Size of the Prize</h3><p>Explore how interventions affect the whole person and compare health, financial and societal returns.</p><b>Explore the opportunity ↗</b></div>
-        </a>
-        <a class="insight-card insight-atlas" href="https://pelld.github.io/population-health-atlas/">
-          <div class="insight-visual atlas-visual" aria-hidden="true"><div class="atlas-map"></div><i class="atlas-dot dot-a"></i><i class="atlas-dot dot-b"></i><i class="atlas-dot dot-c"></i><span>QOF</span></div>
-          <div class="insight-copy"><span class="project-status">Geographic analysis · Demonstration data</span><h3>Population Health Atlas</h3><p>Investigate where recorded long-term conditions cluster and what remains after adjustment for deprivation.</p><b>Open the atlas ↗</b></div>
-        </a>
-        <a class="insight-card insight-pvalue" href="https://pelld.github.io/p-value-explorer/">
-          <div class="insight-visual pvalue-visual" aria-hidden="true"><i style="--h:34%"></i><i style="--h:58%"></i><i style="--h:82%"></i><i style="--h:48%"></i><i class="threshold" style="--h:92%"></i><i style="--h:28%"></i><span>p = .05</span></div>
-          <div class="insight-copy"><span class="project-status">PubMed evidence explorer</span><h3>P-Value Explorer</h3><p>Search PubMed abstracts, extract reported p-values and inspect their distribution around the 0.05 threshold.</p><b>Explore the evidence ↗</b></div>
-        </a>
-      </div>
-      <p class="prototype-note"><strong>About the prototypes:</strong> several projects currently use illustrative or demonstration data to develop the design and analytical approach. Each site explains what its results can—and cannot—show.</p>
-    </div>
-  </section>
+  <div class="project-readout" id="project-readout" aria-live="polite">
+    <span class="readout-index" id="readout-index">00</span>
+    <strong id="readout-title">Move through the questions</strong>
+    <p id="readout-description">The links react, reveal their relationships and open the project directly.</p>
+    <span class="readout-action" id="readout-action">Select a question</span>
+  </div>
 
-  <!-- ============================================================
-       04. BURTREE GAMING STUDIOS
-       ============================================================ -->
-  <section class="games-section" id="games">
-    <div class="shell">
-      <div class="section-title light"><div><p class="kicker">Burtree Gaming Studios</p><h2>Made to be played.</h2></div><p>Small, phone-friendly games built for family, friends and two-player challenges.</p></div>
-      <div class="games-grid">
-        <a class="game-card game-quiz" href="https://pelld.github.io/quiz-duel-stars/"><div class="game-visual"><span class="quiz-bubble">?</span><span class="quiz-bubble second">!</span></div><div class="game-copy"><span>Quiz · Two devices</span><h3>Quiz Duel Stars</h3><p>Fast head-to-head trivia, played together from different phones.</p><b>Play now ↗</b></div></a>
-        <a class="game-card game-nepal" href="https://pelld.github.io/amelia-nepal-game/"><div class="game-visual"><div class="mountain back"></div><div class="mountain front"></div><span class="sun"></span></div><div class="game-copy"><span>Personal adventure</span><h3>Amelia in Nepal</h3><p>A journey through the mountains, made as a personalised game.</p><b>Play now ↗</b></div></a>
-        <a class="game-card game-bike" href="https://pelld.github.io/hunter-dirt-bike-adventure/"><div class="game-visual"><div class="trail"></div><span class="wheel wheel-one"></span><span class="wheel wheel-two"></span><span class="rider">↗</span></div><div class="game-copy"><span>Action · Tricks</span><h3>Hunter's Dirt Bike Adventure</h3><p>Ride, jump and perform tricks across the North Pennines.</p><b>Play now ↗</b></div></a>
-        <a class="game-card game-dash" href="https://pelld.github.io/dirt-bike-dash/"><div class="game-visual speed-lines"><strong>GO!</strong></div><div class="game-copy"><span>Race · Two player</span><h3>Dirt Bike Dash</h3><p>A quick dirt-bike challenge made for racing a friend.</p><b>Play now ↗</b></div></a>
-        <a class="game-card game-animal" href="https://pelld.github.io/animal-dash/"><div class="game-visual animal-faces"><span>●ᴥ●</span><span>•ᴥ•</span><span>●ᴥ●</span></div><div class="game-copy"><span>Arcade · Younger players</span><h3>Animal Dash</h3><p>A bright and simple action game for quick bursts of play.</p><b>Play now ↗</b></div></a>
-      </div>
-    </div>
-  </section>
-
-  <!-- ============================================================
-       05. BLOG ARCHIVE
-       ============================================================ -->
-  <section class="archive shell" id="archive"><div class="archive-number">2016</div><div class="archive-copy"><p class="kicker">Still here, safely archived</p><h2>Jarb: Just another R blog</h2><p>The original collection of short notes on R, SQL, SAS and coding problems. The blog and all its original posts remain available.</p></div><a class="button button-light" href="{{ site.baseurl }}/blog/">Browse the archive →</a></section>
+  <div class="stage-tools" aria-label="Homepage tools">
+    <button type="button" data-directory-open>All projects <span>⌘ K</span></button>
+    <a href="{{ site.baseurl }}/blog/">R blog archive ↗</a>
+  </div>
 </main>
 
 <!-- ============================================================
-     06. ALL-SITES DRAWER
+     04. AUTOMATIC ALL-PROJECTS DRAWER
      ============================================================ -->
 <div class="directory-drawer-layer" id="directory-drawer-layer" aria-hidden="true">
   <button type="button" class="directory-scrim" data-directory-close aria-label="Close all projects"></button>
   <aside class="directory-drawer" role="dialog" aria-modal="true" aria-labelledby="directory-title">
-    <header class="directory-drawer-header"><div><p>All public sites</p><h2 id="directory-title">Projects</h2></div><button type="button" class="directory-close" data-directory-close aria-label="Close all projects">×</button></header>
+    <header class="directory-drawer-header"><div><p>Public GitHub Pages sites</p><h2 id="directory-title">All projects</h2></div><button type="button" class="directory-close" data-directory-close aria-label="Close all projects">×</button></header>
     <label class="directory-search-label" for="directory-search">Search projects</label>
     <input id="directory-search" class="directory-search" type="search" placeholder="Search by name or type" autocomplete="off">
     <div id="site-directory" class="directory-list" aria-live="polite"><p class="directory-loading">Looking for published sites…</p></div>
-    <p class="directory-drawer-note">This list is generated automatically from public GitHub Pages repositories.</p>
+    <p class="directory-drawer-note">Generated automatically from public GitHub Pages repositories.</p>
   </aside>
 </div>
 

--- a/site-directory.js
+++ b/site-directory.js
@@ -10,6 +10,7 @@ const DIRECTORY_CONFIG = {
   excludedRepositories: ["our-days"],
   apiUrl: "https://api.github.com/users/pelld/repos?per_page=100&sort=updated",
   fallbackRepositories: [
+    { name: "patient-flow-explorer", description: "Explore patient pathways, demand, delay and capacity." },
     { name: "where-is-the-art", description: "Find artworks and museums by artist or location." },
     { name: "population-health-system-explorer", description: "Explore relationships across the population health system." },
     { name: "population-health-size-of-prize", description: "Explore the potential impact of population health interventions." },
@@ -24,6 +25,7 @@ const DIRECTORY_CONFIG = {
 };
 
 const DISPLAY_NAMES = {
+  "patient-flow-explorer": "Patient Flow Explorer",
   "where-is-the-art": "Where Is the Art?",
   "population-health-system-explorer": "Population Health: The Whole System",
   "population-health-size-of-prize": "Population Health: Size of the Prize",
@@ -49,7 +51,7 @@ function titleFromRepository(name) {
 function categoryFromRepository(repository) {
   const topics = repository.topics || [];
   if (topics.includes("game") || /game|dash|quiz/.test(repository.name)) return "Game";
-  if (topics.includes("population-health") || repository.name.startsWith("population-health-")) return "Population health";
+  if (topics.includes("population-health") || repository.name.startsWith("population-health-") || repository.name === "patient-flow-explorer") return "Population health";
   if (topics.includes("evidence") || /p-value|evidence/.test(repository.name)) return "Evidence";
   if (topics.includes("tool")) return "Tool";
   return "Web project";


### PR DESCRIPTION
## Direction

This restores the strongest visual idea from the earlier homepage: a connected constellation of glowing project nodes. The difference is that every orbit is now a genuine hyperlink rather than a control for a separate card.

## What is visible

- **Analyse** territory: Patient Flow Explorer, Whole System, Size of the Prize, Population Health Atlas and P-Value Explorer
- **Explore** bridge: Where Is the Art?
- **Play** territory: Quiz Duel Stars, Amelia in Nepal, Hunter's Dirt Bike Adventure, Dirt Bike Dash and Animal Dash

## Interaction

- click any orbit to open the project directly
- hover or focus to enlarge the orbit, reveal an arrow and highlight related projects
- relationship lines change to the selected project's colour
- subtle pointer lighting, parallax and magnetic movement
- a slim information rail replaces the previous project card
- **All / Analyse / Explore / Play** filters remain available
- arrow-key navigation and **Ctrl/Cmd + K** project-index shortcut
- searchable automatic project drawer
- responsive linked-grid version for phones
- reduced-motion support

## Removed

- the question-field layout
- the “Things built to understand things” slogan
- stacked project cards and separate project information cards

## Principle

The old visual language is retained, but its objects now behave exactly as visitors expect: the circles themselves are links. The full game collection is a major, visible part of the constellation rather than an afterthought.